### PR TITLE
refactor: simplify GitHub Action and improve release compatibility

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -13,19 +13,15 @@ on:
       policy_path:
         description: 'Path to save the network policy file'
         required: false
-        default: './jibril/netpolicy.yaml'
-      agent_version:
-        description: 'Version to use for the agent'
-        required: false
-        default: '1.0.0'
+        default: '/etc/jibril/netpolicy.yaml'
       garnetctl_version:
-        description: 'Version of garnetctl CLI to download'
+        description: 'Version of garnetctl CLI to download (without v prefix)'
         required: false
         default: 'latest'
       jibril_version:
-        description: 'Jibril version for the daemon'
+        description: 'Jibril version for the daemon (without v prefix)'
         required: false
-        default: 'latest'
+        default: '0.0'
 
 jobs:
   scan:
@@ -40,6 +36,5 @@ jobs:
           api_token: ${{ inputs.api_token }}
           api_url: ${{ inputs.api_url }}
           policy_path: ${{ inputs.policy_path }}
-          agent_version: ${{ inputs.agent_version }}
           garnetctl_version: ${{ inputs.garnetctl_version }}
           jibril_version: ${{ inputs.jibril_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,18 @@ on:
         description: 'API URL for GarnetAI service'
         required: false
         default: 'https://api.garnet.ai'
+      policy_path:
+        description: 'Path to save the network policy file'
+        required: false
+        default: '/etc/jibril/netpolicy.yaml'
+      garnetctl_version:
+        description: 'Version of garnetctl CLI to download (without v prefix)'
+        required: false
+        default: 'latest'
+      jibril_version:
+        description: 'Jibril version for the daemon (without v prefix)'
+        required: false
+        default: '0.0'
 
 jobs:
   test:
@@ -18,15 +30,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        
       - name: Run GarnetAI Action
         uses: ./
         with:
-          api_token: ${{ github.event.inputs.api_token }}
-          api_url: ${{ github.event.inputs.api_url }}
+          api_token: ${{ inputs.api_token }}
+          api_url: ${{ inputs.api_url }}
+          policy_path: ${{ inputs.policy_path }}
+          garnetctl_version: ${{ inputs.garnetctl_version }}
+          jibril_version: ${{ inputs.jibril_version }}

--- a/README.md
+++ b/README.md
@@ -75,10 +75,9 @@ jobs:
         with:
           api_token: ${{ secrets.GARNET_API_TOKEN }}
           api_url: https://dev-api.garnet.ai
-          policy_path: ./custom/path/policy.yaml
-          agent_version: 1.1.0
-          garnetctl_version: 2.3.4
-          jibril_version: v0.9.5
+          policy_path: /etc/jibril/netpolicy.yaml
+          garnetctl_version: 1.2.0
+          jibril_version: 0.9.5
 ```
 
 ## Inputs
@@ -87,31 +86,33 @@ jobs:
 |------|-------------|----------|---------|
 | `api_token` | API token for GarnetAI service | Yes | N/A |
 | `api_url` | API URL for GarnetAI service | No | `https://api.garnet.ai` |
-| `policy_path` | Path to save the network policy file | No | `./jibril/netpolicy.yaml` |
-| `agent_version` | Version to use for the agent | No | `1.0.0` |
+| `policy_path` | Path to save the network policy file | No | `/etc/jibril/netpolicy.yaml` |
 | `garnetctl_version` | Version of garnetctl CLI to download | No | `latest` |
-| `jibril_version` | Jibril release version for the daemon | No | empty (uses latest) |
+| `jibril_version` | Jibril release version (without v prefix) | No | `0.0` |
 
 ## How It Works
 
 When this action runs, it:
 
-1. Downloads and configures the garnetctl CLI tool
+1. Downloads the necessary tools from GitHub releases:
+   - garnetctl from garnet-org/garnetctl-releases
+   - Jibril loader from listendev/jibril-releases
 2. Creates a GitHub context file with workflow information
 3. Creates a Garnet agent using the GitHub context
-4. Creates an agent configuration file
+4. Uses the configuration file from ./config/jibril.yaml
 5. Retrieves the network policy for the repository and workflow
-6. Starts the Jibril security daemon
+6. Starts the Jibril loader directly using sudo
 
-The security daemon runs in the background for the duration of your workflow, monitoring for suspicious activity.
+The security monitoring runs in the background for the duration of your workflow, detecting suspicious activity. The configuration includes extensive detection events for file access, execution monitoring, and network peer analysis.
 
 ## Troubleshooting
 
 If you encounter issues:
 
 1. Verify your API token has the proper permissions
-2. Check that your action has access to the internet
+2. Check that your workflow has sudo access for running the loader
 3. Ensure the agent can properly register with GarnetAI
+4. Check that the specified versions of garnetctl and Jibril are available in their respective release repositories
 
 For more detailed errors, check the GitHub Actions logs.
 

--- a/action.yml
+++ b/action.yml
@@ -15,50 +15,99 @@ inputs:
   policy_path:
     description: 'Path to save the network policy file'
     required: false
-    default: './jibril/netpolicy.yaml'
-  agent_version:
-    description: 'Version to use for the agent'
-    required: false
-    default: '1.0.0'
+    default: '/etc/jibril/netpolicy.yaml'
   garnetctl_version:
-    description: 'Version of garnetctl CLI to download'
+    description: 'Version of garnetctl CLI to download (without v prefix)'
     required: false
     default: 'latest'
   jibril_version:
-    description: 'Jibril release version for the daemon (leave empty for latest)'
+    description: 'Jibril release version for the daemon (without v prefix)'
     required: false
-    default: ''
+    default: '0.0'
 
 runs:
   using: "composite"
   steps:
-    - name: Setup GarnetAI tools
+    - name: Download and setup tools
       shell: bash
       run: |
-        # Try to use vendored garnetctl tool first
-        echo "Checking for vendored garnetctl..."
-        VENDORED_PATH="${{ github.action_path }}/bin/garnetctl"
-        if [ -f "$VENDORED_PATH" ]; then
-          echo "Using vendored garnetctl from $VENDORED_PATH"
-          cp "$VENDORED_PATH" ./garnetctl
-        else
-          # Fall back to downloading if vendored binary isn't available
-          echo "Vendored garnetctl not found. Downloading version ${{ inputs.garnetctl_version }}..."
-          curl -sL "${{ inputs.api_url }}/cli/download/${{ inputs.garnetctl_version }}" -o garnetctl
+        # Set up versions
+        GARNETCTL_VERSION="${{ inputs.garnetctl_version }}"
+        JIBRIL_VERSION="${{ inputs.jibril_version }}"
+        
+        # Ensure we have the proper version format
+        if [[ "$GARNETCTL_VERSION" != "latest" && "$GARNETCTL_VERSION" != v* ]]; then
+          GARNETCTL_VERSION="v$GARNETCTL_VERSION"
         fi
         
-        chmod +x ./garnetctl
+        if [[ "$JIBRIL_VERSION" != v* ]]; then
+          JIBRIL_VERSION="v$JIBRIL_VERSION"
+        fi
         
-        # Create directories
-        mkdir -p $(dirname "${{ inputs.policy_path }}")
+        # Download garnetctl from GitHub
+        echo "Downloading garnetctl $GARNETCTL_VERSION..."
         
-        # Configure garnetctl base URL and set token
-        ./garnetctl config set-baseurl ${{ inputs.api_url }}
-        ./garnetctl config set-token ${{ inputs.api_token }}
+        # Map OS and arch to garnetctl release names
+        OS=$(uname -s)
+        ARCH=$(uname -m)
+        
+        # Convert to garnetctl naming format
+        if [ "$OS" = "Linux" ]; then
+          GARNET_OS="Linux"
+        elif [ "$OS" = "Darwin" ]; then
+          GARNET_OS="Darwin"
+        else
+          echo "Unsupported OS: $OS"
+          exit 1
+        fi
+        
+        if [ "$ARCH" = "x86_64" ]; then
+          GARNET_ARCH="x86_64"
+        elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+          GARNET_ARCH="arm64"
+        else
+          echo "Unsupported architecture: $ARCH"
+          exit 1
+        fi
+        
+        # Construct download URL
+        if [ "$GARNETCTL_VERSION" = "latest" ]; then
+          GARNETCTL_URL="https://github.com/garnet-org/garnetctl-releases/releases/latest/download/garnetctl_${GARNET_OS}_${GARNET_ARCH}.tar.gz"
+        else
+          GARNETCTL_URL="https://github.com/garnet-org/garnetctl-releases/releases/download/$GARNETCTL_VERSION/garnetctl_${GARNET_OS}_${GARNET_ARCH}.tar.gz"
+        fi
+        
+        echo "Downloading garnetctl from: $GARNETCTL_URL"
+        
+        # Create temporary directory for extraction
+        GARNETCTL_TMP_DIR=$(mktemp -d)
+        
+        # Download and extract
+        curl -sL "$GARNETCTL_URL" | tar -xz -C "$GARNETCTL_TMP_DIR"
+        
+        # Move binary to path
+        mv "$GARNETCTL_TMP_DIR/garnetctl" /usr/local/bin/garnetctl
+        chmod +x /usr/local/bin/garnetctl
+        
+        # Clean up
+        rm -rf "$GARNETCTL_TMP_DIR"
+        
+        # Download Jibril loader
+        echo "Downloading Jibril loader $JIBRIL_VERSION..."
+        
+        JIBRIL_URL="https://github.com/listendev/jibril-releases/releases/download/$JIBRIL_VERSION/loader"
+        echo "Downloading Jibril loader from: $JIBRIL_URL"
+        curl -sL -o /usr/local/bin/loader "$JIBRIL_URL"
+        chmod +x /usr/local/bin/loader
+        
+        # Configure garnetctl
+        garnetctl config set-baseurl ${{ inputs.api_url }}
+        garnetctl config set-token ${{ inputs.api_token }}
 
-    - name: Create GitHub context file
+    - name: Create GitHub context and agent
       shell: bash
       run: |
+        # Step 1: Create the GitHub context file
         echo "Creating GitHub context file..."
         cat > github-context.json << EOF
         {
@@ -76,72 +125,48 @@ runs:
         }
         EOF
 
-    - name: Create agent
-      shell: bash
-      run: |
+        # Step 2: Create the agent
         echo "Creating GitHub agent..."
-        AGENT_INFO=$(./garnetctl create agent \
-          --version "${{ inputs.agent_version }}" \
+        AGENT_INFO=$(garnetctl create agent \
+          --version "1.0.0" \
           --ip "127.0.0.1" \
           --machine-id "github-${{ github.run_id }}" \
           --kind github \
           --context-file github-context.json)
-        
+
         # Extract agent details
         AGENT_ID=$(echo "$AGENT_INFO" | jq -r '.id')
         AGENT_TOKEN=$(echo "$AGENT_INFO" | jq -r '.agent_token')
-        
+
         echo "Created agent with ID: $AGENT_ID"
-        
-        # Save for other steps
         echo "AGENT_ID=$AGENT_ID" >> $GITHUB_ENV
         echo "AGENT_TOKEN=$AGENT_TOKEN" >> $GITHUB_ENV
 
-    - name: Create agent config file
+    - name: Configure and start monitoring
       shell: bash
       run: |
-        echo "Creating agent configuration file..."
-        cat > agent-config.yaml << EOF
-        daemon:
-          loglevel: info
-          debug: false
-        
-        config:
-          plugins:
-          - jibril:printers:varlog
-          - jibril:printers:garnet
-        EOF
-
-    - name: Get network policy
-      shell: bash
-      run: |
+        # Step 3: Get network policy
         echo "Getting network policy..."
         REPO_ID="${{ github.repository }}"
         WORKFLOW="${{ github.workflow }}"
-        
+
         # Get the network policy and save it to the specified path
-        ./garnetctl get network-policy merged \
+        garnetctl get network-policy merged \
           --repository-id "$REPO_ID" \
           --workflow-name "$WORKFLOW" \
           --format jibril \
           --output "${{ inputs.policy_path }}"
-        
-        echo "Network policy saved to ${{ inputs.policy_path }}"
 
-    - name: Start security monitoring
-      shell: bash
-      run: |
-        echo "Starting security monitoring daemon..."
+        echo "Network policy saved to ${{ inputs.policy_path }}"
         
-        # Start command with basic parameters
-        START_CMD="./garnetctl start-daemon --config agent-config.yaml --agent-token ${{ env.AGENT_TOKEN }}"
+        # Set up environment variables for configuration
+        export POLICY_PATH="${{ inputs.policy_path }}"
+
+        # Step 4: Start Jibril with loader using config from ./config
+        echo "Starting Jibril security monitoring..."
+        export GARNET_AGENT_TOKEN="${{ env.AGENT_TOKEN }}"
         
-        # Add release parameter only if a version was specified
-        if [ -n "${{ inputs.jibril_version }}" ]; then
-          START_CMD="$START_CMD --release ${{ inputs.jibril_version }}"
-        fi
+        echo "Running Jibril loader with config from ./config/jibril.yaml"
+        sudo -E loader --config ./config/jibril.yaml --systemd enable-now
         
-        # Execute the command
-        eval "$START_CMD"
-        
-        echo "Security monitoring daemon started"
+        echo "Security monitoring started"

--- a/config/jibril.yaml
+++ b/config/jibril.yaml
@@ -1,0 +1,84 @@
+#
+# Jibril Configuration File.
+#
+log-level: info
+stdout: stdout
+stderr: stderr
+chop-lines: false
+no-health: false
+profiler: false
+cardinal: true
+daemon: false
+notify: false
+extension:
+  - config
+  - data
+  - jibril
+plugin:
+  - jibril:hold
+  - jibril:procfs
+  - jibril:printers
+  - jibril:detect
+  - jibril:netpolicy:file=/etc/jibril/netpolicy.yaml
+printer:
+  - jibril:printers:varlog
+  - jibril:printers:garnet:error_log_rate=5s:warn_log_rate=1s
+event:
+  - jibril:detect:flow
+  - jibril:detect:file_example
+  - jibril:detect:capabilities_modification
+  - jibril:detect:code_modification_through_procfs
+  - jibril:detect:core_pattern_access
+  - jibril:detect:cpu_fingerprint
+  - jibril:detect:credentials_files_access
+  - jibril:detect:filesystem_fingerprint
+  - jibril:detect:java_debug_lib_load
+  - jibril:detect:java_instrument_lib_load
+  - jibril:detect:machine_fingerprint
+  - jibril:detect:os_fingerprint
+  - jibril:detect:os_network_fingerprint
+  - jibril:detect:os_status_fingerprint
+  - jibril:detect:package_repo_config_modification
+  - jibril:detect:pam_config_modification
+  - jibril:detect:sched_debug_access
+  - jibril:detect:shell_config_modification
+  - jibril:detect:ssl_certificate_access
+  - jibril:detect:sudoers_modification
+  - jibril:detect:sysrq_access
+  - jibril:detect:unprivileged_bpf_config_access
+  - jibril:detect:global_shlib_modification
+  - jibril:detect:environ_read_from_procfs
+  - jibril:detect:binary_self_deletion
+  - jibril:detect:crypto_miner_files
+  - jibril:detect:auth_logs_tamper
+  - jibril:detect:exec_example
+  - jibril:detect:binary_executed_by_loader
+  - jibril:detect:code_on_the_fly
+  - jibril:detect:data_encoder_exec
+  - jibril:detect:denial_of_service_tools
+  - jibril:detect:exec_from_unusual_dir
+  - jibril:detect:file_attribute_change
+  - jibril:detect:hidden_elf_exec
+  - jibril:detect:interpreter_shell_spawn
+  - jibril:detect:net_filecopy_tool_exec
+  - jibril:detect:net_mitm_tool_exec
+  - jibril:detect:net_scan_tool_exec
+  - jibril:detect:net_sniff_tool_exec
+  - jibril:detect:net_suspicious_tool_exec
+  - jibril:detect:net_suspicious_tool_shell
+  - jibril:detect:passwd_usage
+  - jibril:detect:runc_suspicious_exec
+  - jibril:detect:webserver_exec
+  - jibril:detect:webserver_shell_exec
+  - jibril:detect:crypto_miner_execution
+  - jibril:detect:peer_example
+  - jibril:detect:adult_domain_access
+  - jibril:detect:badware_domain_access
+  - jibril:detect:dyndns_domain_access
+  - jibril:detect:fake_domain_access
+  - jibril:detect:gambling_domain_access
+  - jibril:detect:piracy_domain_access
+  - jibril:detect:plaintext_communication
+  - jibril:detect:threat_domain_access
+  - jibril:detect:tracking_domain_access
+  - jibril:detect:vpnlike_domain_access

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,65 @@
+# GarnetAI Action Test Script
+
+This script (`action.sh`) allows you to test the GarnetAI GitHub Action locally without having to run it in a GitHub Actions workflow.
+
+## Prerequisites
+
+- bash
+- curl
+- jq
+- git
+- sudo access
+
+## Usage
+
+1. Make the script executable if needed:
+   ```
+   chmod +x action.sh
+   ```
+
+2. Set environment variables to configure the script:
+   ```
+   export API_TOKEN="your-garnet-api-token"
+   export API_URL="https://api.garnet.ai"  # Optional, default is shown
+   export POLICY_PATH="/etc/jibril/netpolicy.yaml"  # Optional, default is shown
+   export GARNETCTL_VERSION="latest"  # Optional, default is shown
+   export JIBRIL_VERSION="0.0"  # Optional, default is shown
+   ```
+
+3. Run the script:
+   ```
+   sudo ./action.sh
+   ```
+
+## What the Script Does
+
+The script mimics the behavior of the GitHub Action:
+
+1. Downloads garnetctl from GitHub releases
+2. Downloads the Jibril loader from GitHub releases
+3. Creates a simulated GitHub context
+4. Creates a Garnet agent
+5. Fetches a network policy
+6. Runs the Jibril loader with sudo using the config from `./config/jibril.yaml`
+
+## Cleanup
+
+The script will run Jibril with `--systemd`, which means it will be installed as a systemd service. To stop and remove the service after testing, you may need to:
+
+1. Find the service name:
+   ```
+   sudo systemctl list-units | grep jibril
+   ```
+
+2. Stop and disable the service:
+   ```
+   sudo systemctl stop <service-name>
+   sudo systemctl disable <service-name>
+   ```
+
+## Troubleshooting
+
+- Make sure you have a valid API token
+- Verify you have sudo access
+- Check that the specified version of garnetctl and Jibril are available in their respective release repositories
+- If you encounter issues with the config file, make sure `./config/jibril.yaml` exists and contains valid configuration

--- a/scripts/action.sh
+++ b/scripts/action.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+set -e
+
+# Default values
+API_TOKEN=${API_TOKEN:-"YOUR_TOKEN_HERE"}
+API_URL=${API_URL:-"https://api.garnet.ai"}
+POLICY_PATH=${POLICY_PATH:-"/etc/jibril/netpolicy.yaml"}
+GARNETCTL_VERSION=${GARNETCTL_VERSION:-"latest"}
+JIBRIL_VERSION=${JIBRIL_VERSION:-"0.0"}
+
+# Print configuration
+echo "Testing GarnetAI Action with:"
+echo "  API URL: $API_URL"
+echo "  Policy Path: $POLICY_PATH"
+echo "  GarnetCtl Version: $GARNETCTL_VERSION"
+echo "  Jibril Version: $JIBRIL_VERSION"
+
+# Step 1: Download and setup tools
+echo "=== Step 1: Download and setup tools ==="
+
+# Ensure we have the proper version format
+if [[ "$GARNETCTL_VERSION" != "latest" && "$GARNETCTL_VERSION" != v* ]]; then
+  GARNETCTL_VERSION="v$GARNETCTL_VERSION"
+fi
+
+if [[ "$JIBRIL_VERSION" != v* ]]; then
+  JIBRIL_VERSION="v$JIBRIL_VERSION"
+fi
+
+# Platform detection
+PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+# Download garnetctl from GitHub
+echo "Downloading garnetctl $GARNETCTL_VERSION..."
+
+# Map OS and arch to garnetctl release names
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+# Convert to garnetctl naming format
+if [ "$OS" = "Linux" ]; then
+  GARNET_OS="Linux"
+elif [ "$OS" = "Darwin" ]; then
+  GARNET_OS="Darwin"
+else
+  echo "Unsupported OS: $OS"
+  exit 1
+fi
+
+if [ "$ARCH" = "x86_64" ]; then
+  GARNET_ARCH="x86_64"
+elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+  GARNET_ARCH="arm64"
+else
+  echo "Unsupported architecture: $ARCH"
+  exit 1
+fi
+
+# Construct download URL
+if [ "$GARNETCTL_VERSION" = "latest" ]; then
+  GARNETCTL_URL="https://github.com/garnet-org/garnetctl-releases/releases/latest/download/garnetctl_${GARNET_OS}_${GARNET_ARCH}.tar.gz"
+else
+  GARNETCTL_URL="https://github.com/garnet-org/garnetctl-releases/releases/download/$GARNETCTL_VERSION/garnetctl_${GARNET_OS}_${GARNET_ARCH}.tar.gz"
+fi
+
+echo "Downloading garnetctl from: $GARNETCTL_URL"
+
+# Create temporary directory for extraction
+GARNETCTL_TMP_DIR=$(mktemp -d)
+
+# Download and extract
+curl -sL "$GARNETCTL_URL" | tar -xz -C "$GARNETCTL_TMP_DIR"
+
+# Move binary to path
+sudo mv "$GARNETCTL_TMP_DIR/garnetctl" /usr/local/bin/garnetctl
+sudo chmod +x /usr/local/bin/garnetctl
+
+# Clean up
+rm -rf "$GARNETCTL_TMP_DIR"
+
+# Download Jibril loader
+echo "Downloading Jibril loader $JIBRIL_VERSION..."
+
+JIBRIL_URL="https://github.com/listendev/jibril-releases/releases/download/$JIBRIL_VERSION/loader"
+echo "Downloading Jibril loader from: $JIBRIL_URL"
+sudo curl -sL -o /usr/local/bin/loader "$JIBRIL_URL"
+sudo chmod +x /usr/local/bin/loader
+
+# Configure garnetctl
+echo "Configuring garnetctl..."
+garnetctl config set-baseurl "$API_URL"
+garnetctl config set-token "$API_TOKEN"
+
+# Step 2: Create GitHub context and agent
+echo "=== Step 2: Create GitHub context and agent ==="
+
+# Create a simulated GitHub context file
+echo "Creating GitHub context file..."
+cat > github-context.json << EOF
+{
+  "job": "local-test",
+  "run_id": "123456789",
+  "workflow": "Local Test Workflow",
+  "repository": "garnet-org/action",
+  "repository_owner": "garnet-org",
+  "event_name": "local-test",
+  "ref": "refs/heads/main",
+  "sha": "$(git rev-parse HEAD || echo "0000000000000000000000000000000000000000")",
+  "actor": "$(whoami)",
+  "runner_os": "$PLATFORM",
+  "runner_arch": "$ARCH"
+}
+EOF
+
+echo "Creating GitHub agent..."
+AGENT_INFO=$(garnetctl create agent \
+  --version "1.0.0" \
+  --ip "127.0.0.1" \
+  --machine-id "local-$(hostname)" \
+  --kind github \
+  --context-file github-context.json)
+
+# Extract agent details
+AGENT_ID=$(echo "$AGENT_INFO" | jq -r '.id')
+AGENT_TOKEN=$(echo "$AGENT_INFO" | jq -r '.agent_token')
+
+echo "Created agent with ID: $AGENT_ID"
+export AGENT_TOKEN
+
+# Step 3: Configure and start monitoring
+echo "=== Step 3: Configure and start monitoring ==="
+
+# Get network policy
+echo "Getting network policy..."
+REPO_ID="garnet-org/action"
+WORKFLOW="Local Test Workflow"
+
+# Get the network policy and save it to the specified path
+echo "Fetching network policy for $REPO_ID/$WORKFLOW..."
+garnetctl get network-policy merged \
+  --repository-id "$REPO_ID" \
+  --workflow-name "$WORKFLOW" \
+  --format jibril \
+  --output "$POLICY_PATH"
+
+echo "Network policy saved to $POLICY_PATH"
+
+# Set up environment variables for configuration
+export POLICY_PATH
+
+# Step 4: Start Jibril with loader
+echo "=== Step 4: Starting Jibril security monitoring ==="
+export GARNET_AGENT_TOKEN="$AGENT_TOKEN"
+
+echo "Running Jibril loader..."
+echo "Command: sudo -E loader --config ./config/jibril.yaml --systemd enable-now"
+
+# Prompt user before running with sudo
+read -p "Ready to run Jibril with sudo. Continue? (y/n) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  sudo -E loader --config ./config/jibril.yaml --systemd enable-now
+  echo "Security monitoring installed and started"
+else
+  echo "Skipped running Jibril loader. You can run it manually with:"
+  echo "  sudo -E loader --config ./config/jibril.yaml --systemd enable-now"
+fi
+
+echo "=== Test completed ==="
+echo "To stop the Jibril service, you may need to find and stop the systemd service"


### PR DESCRIPTION
## Summary
- Download tools directly from GitHub releases
- Update URL formats for garnetctl and Jibril loader
- Use existing config file from ./config directory
- Use enable-now flag with systemd
- Remove agent_version parameter
- Update workflows and documentation
- Add test script for local testing