### PR TITLE
fix: use static path for network policy file

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -13,7 +13,7 @@ on:
       policy_path:
         description: 'Path to save the network policy file'
         required: false
-        default: '/etc/jibril/netpolicy.yaml'
+        default: './config/netpolicy.yaml'
       garnetctl_version:
         description: 'Version of garnetctl CLI to download (without v prefix)'
         required: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:
       policy_path:
         description: 'Path to save the network policy file'
         required: false
-        default: '/etc/jibril/netpolicy.yaml'
+        default: './config/netpolicy.yaml'
       garnetctl_version:
         description: 'Version of garnetctl CLI to download (without v prefix)'
         required: false

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ jobs:
         with:
           api_token: ${{ secrets.GARNET_API_TOKEN }}
           api_url: https://dev-api.garnet.ai
-          policy_path: /etc/jibril/netpolicy.yaml
+          policy_path: ./config/netpolicy.yaml
           garnetctl_version: 1.2.0
           jibril_version: 0.9.5
 ```
@@ -86,7 +86,7 @@ jobs:
 |------|-------------|----------|---------|
 | `api_token` | API token for GarnetAI service | Yes | N/A |
 | `api_url` | API URL for GarnetAI service | No | `https://api.garnet.ai` |
-| `policy_path` | Path to save the network policy file | No | `/etc/jibril/netpolicy.yaml` |
+| `policy_path` | Path to save the network policy file | No | `./config/netpolicy.yaml` |
 | `garnetctl_version` | Version of garnetctl CLI to download | No | `latest` |
 | `jibril_version` | Jibril release version (without v prefix) | No | `0.0` |
 

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   policy_path:
     description: 'Path to save the network policy file'
     required: false
-    default: '/etc/jibril/netpolicy.yaml'
+    default: './config/netpolicy.yaml'
   garnetctl_version:
     description: 'Version of garnetctl CLI to download (without v prefix)'
     required: false
@@ -150,6 +150,9 @@ runs:
         REPO_ID="${{ github.repository }}"
         WORKFLOW="${{ github.workflow }}"
 
+        # Create directory for policy file if it doesn't exist
+        mkdir -p $(dirname "${{ inputs.policy_path }}")
+        
         # Get the network policy and save it to the specified path
         garnetctl get network-policy merged \
           --repository-id "$REPO_ID" \
@@ -158,9 +161,6 @@ runs:
           --output "${{ inputs.policy_path }}"
 
         echo "Network policy saved to ${{ inputs.policy_path }}"
-        
-        # Set up environment variables for configuration
-        export POLICY_PATH="${{ inputs.policy_path }}"
 
         # Step 4: Start Jibril with loader using config from ./config
         echo "Starting Jibril security monitoring..."

--- a/config/jibril.yaml
+++ b/config/jibril.yaml
@@ -19,7 +19,7 @@ plugin:
   - jibril:procfs
   - jibril:printers
   - jibril:detect
-  - jibril:netpolicy:file=/etc/jibril/netpolicy.yaml
+  - jibril:netpolicy:file=./config/netpolicy.yaml
 printer:
   - jibril:printers:varlog
   - jibril:printers:garnet:error_log_rate=5s:warn_log_rate=1s

--- a/scripts/action.sh
+++ b/scripts/action.sh
@@ -4,7 +4,7 @@ set -e
 # Default values
 API_TOKEN=${API_TOKEN:-"YOUR_TOKEN_HERE"}
 API_URL=${API_URL:-"https://api.garnet.ai"}
-POLICY_PATH=${POLICY_PATH:-"/etc/jibril/netpolicy.yaml"}
+POLICY_PATH=${POLICY_PATH:-"./config/netpolicy.yaml"}
 GARNETCTL_VERSION=${GARNETCTL_VERSION:-"latest"}
 JIBRIL_VERSION=${JIBRIL_VERSION:-"0.0"}
 
@@ -136,6 +136,9 @@ echo "Getting network policy..."
 REPO_ID="garnet-org/action"
 WORKFLOW="Local Test Workflow"
 
+# Create directory for policy file if it doesn't exist
+mkdir -p $(dirname "$POLICY_PATH")
+
 # Get the network policy and save it to the specified path
 echo "Fetching network policy for $REPO_ID/$WORKFLOW..."
 garnetctl get network-policy merged \
@@ -145,9 +148,6 @@ garnetctl get network-policy merged \
   --output "$POLICY_PATH"
 
 echo "Network policy saved to $POLICY_PATH"
-
-# Set up environment variables for configuration
-export POLICY_PATH
 
 # Step 4: Start Jibril with loader
 echo "=== Step 4: Starting Jibril security monitoring ==="


### PR DESCRIPTION
- Change policy path references to static ./config/netpolicy.yaml
- Remove environment variable usage for policy path 
- Simplify configuration
- Ensure directories are created as needed