### PR TITLE
fix: add validation for garnetctl API configuration

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -107,9 +107,23 @@ runs:
         chmod +x /usr/local/bin/loader
         echo "Jibril loader downloaded and installed successfully ✅"
         
-        # Configure garnetctl
-        garnetctl config set-baseurl ${{ inputs.api_url }}
-        garnetctl config set-token ${{ inputs.api_token }}
+        # Pre-flight checks for API configuration
+        echo "Validating API configuration..."
+        if [ -z "${{ inputs.api_token }}" ]; then
+          echo "❌ ERROR: api_token is required but was not provided"
+          exit 1
+        fi
+        
+        API_URL="${{ inputs.api_url }}"
+        if [ -z "$API_URL" ]; then
+          API_URL="https://api.garnet.ai"
+          echo "⚠️ WARNING: api_url not specified, using default: $API_URL"
+        fi
+        
+        # Configure garnetctl with default URL if needed
+        echo "Configuring garnetctl with URL: $API_URL"
+        garnetctl config set-baseurl "$API_URL"
+        garnetctl config set-token "${{ inputs.api_token }}"
         echo "Download and setup tools completed ✅"
 
     - name: Create GitHub context and agent


### PR DESCRIPTION
## Summary
- Add validation checks for API token and base URL prior to configuration
- Provide clear error message when API token is missing 
- Add default URL handling with warning when not specified
- Fix issue where garnetctl commands were receiving empty arguments