### PR TITLE
feat(pr-comment): observation-only fallback comment per locked Runtime Review spec

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Test
+        run: npm run test
+
       - name: Build
         run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
   "scripts": {
     "prepare": "node scripts/setup-git-hooks.js",
     "typecheck": "node ./node_modules/typescript/bin/tsc -p jsconfig.json --noEmit",
+    "test": "node --test src/",
     "build": "ncc build src/main.js -o dist/main --license licenses.txt && ncc build src/post.js -o dist/post --license licenses.txt && perl -pi -e 's/\\r$//' dist/main/index.js dist/post/index.js",
-    "validate": "npm run typecheck && npm run build"
+    "validate": "npm run typecheck && npm run test && npm run build"
   },
   "dependencies": {
     "@actions/artifact": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "prepare": "node scripts/setup-git-hooks.js",
     "typecheck": "node ./node_modules/typescript/bin/tsc -p jsconfig.json --noEmit",
-    "test": "node --test src/",
+    "test": "node --test src/*.test.js",
     "build": "ncc build src/main.js -o dist/main --license licenses.txt && ncc build src/post.js -o dist/post --license licenses.txt && perl -pi -e 's/\\r$//' dist/main/index.js dist/post/index.js",
     "validate": "npm run typecheck && npm run test && npm run build"
   },

--- a/src/profile-comment.js
+++ b/src/profile-comment.js
@@ -1,6 +1,7 @@
 import { z } from "zod"
 import { getOptionalRecord } from "./shared.js"
 
+export const RUNTIME_REVIEW_MARKER = "garnet-runtime-review"
 export const ACTION_COMMENT_MARKER = "garnet-action-pr-comment:v1"
 export const COMMIT_MARKER_PREFIX = "garnet-pr-commit:"
 export const LEGACY_COMMENT_STATE_MARKER = "garnet-runtime-visibility"
@@ -29,6 +30,7 @@ const COMMENT_STATE_MARKER_PREFIX = "garnet-action-comment-state:"
 
 /**
  * @typedef {{
+ *   remote_address?: string
  *   remote_names: string[]
  *   proc_trees: ProcTree[]
  *   result: ProfileResult
@@ -106,10 +108,12 @@ const ASSERTION_SCHEMA = z.looseObject({
 const PEER_SCHEMA = z
     .looseObject({
         result: PROFILE_RESULT_SCHEMA,
+        remote_address: z.string().optional(),
         remote_names: z.array(z.string()),
         proc_trees: z.array(PROC_TREE_SCHEMA),
     })
     .transform(peer => ({
+        remote_address: peer.remote_address ?? "",
         remote_names: peer.remote_names.filter(name => name.length > 0),
         proc_trees: peer.proc_trees,
         result: peer.result,
@@ -365,23 +369,31 @@ export function mergeCommentStates(states) {
 export function renderCommentBody(state) {
     const metadata = encodeCommentState(state)
     const profiles = [...state.profiles].sort(compareProfiles)
-    const headline = renderHeadline(profiles)
-    const summaryTable = renderSummaryTable(profiles)
-    const sections = profiles.map(profile => renderProfileSection(profile)).join("\n\n")
     const commitSha = getCommentCommitSha(profiles)
-
-    return [
+    const parts = [
+        `<!-- ${RUNTIME_REVIEW_MARKER} -->`,
         `<!-- ${ACTION_COMMENT_MARKER} -->`,
         `<!-- ${COMMIT_MARKER_PREFIX}${commitSha} -->`,
         `<!-- ${COMMENT_STATE_MARKER_PREFIX}${metadata} -->`,
         "## Garnet Runtime Review",
+        renderMetaLine(profiles),
         "",
-        headline,
-        "",
-        summaryTable,
-        "",
-        sections,
-    ].join("\n")
+        renderHeadline(profiles),
+    ]
+
+    const inlineTrees = renderInlineTrees(profiles)
+    if (inlineTrees !== "") {
+        parts.push("", inlineTrees)
+    }
+
+    const quietJobLines = renderQuietJobLines(profiles)
+    if (quietJobLines !== "") {
+        parts.push("", quietJobLines)
+    }
+
+    parts.push("", renderEvidenceFold(profiles), "", "---", renderFooter(profiles))
+
+    return parts.join("\n")
 }
 
 /**
@@ -415,251 +427,387 @@ export function parseCommentState(body) {
  * @param {NormalizedProfile[]} profiles
  * @returns {string}
  */
-function renderHeadline(profiles) {
-    const failedJobs = profiles.filter(profile => getAssertionState(profile) === "failed").length
-    const attentionJobs = profiles.filter(profile => getAssertionState(profile) === "attention").length
-    const passedJobs = profiles.length - failedJobs - attentionJobs
+function renderMetaLine(profiles) {
+    const repository = getDisplayValue(profiles[0]?.github.repository ?? "", "unknown-repository")
+    const sha = shortSha(getCommentCommitSha(profiles))
+    const jobCount = profiles.length
     const workflowCount = new Set(profiles.map(profile => getWorkflowKey(profile))).size
-    const across = `across ${workflowCount} workflow${workflowCount === 1 ? "" : "s"}`
 
-    if (failedJobs > 0) {
-        const rest = []
-        if (attentionJobs > 0) {
-            rest.push(`${attentionJobs} attention`)
-        }
-        rest.push(`${passedJobs} passed`)
-        return `🛑 **Failed** — ${failedJobs} job${failedJobs === 1 ? "" : "s"} failed assertions · ${rest.join(" · ")} ${across}`
-    }
-
-    if (attentionJobs > 0) {
-        return `🔍 **Attention** — ${attentionJobs} job${attentionJobs === 1 ? "" : "s"} flagged for attention · ${passedJobs} passed ${across}`
-    }
-
-    return `✅ **Passed** — ${passedJobs} job${passedJobs === 1 ? "" : "s"} passed assertions ${across}`
+    return `${repository} · ${getDisplayValue(sha, "unknown-commit")} · ${pluralize(jobCount, "job")} · ${pluralize(workflowCount, "workflow")}`
 }
 
 /**
  * @param {NormalizedProfile[]} profiles
  * @returns {string}
  */
-function renderSummaryTable(profiles) {
-    const rows = profiles.map(profile => {
-        const workflowLabel = escapeMarkdown(getDisplayValue(profile.github.workflow, "unknown"))
-        const runLabel =
-            profile.github.run_id !== ""
-                ? formatRunMarkdownLink(profile.github.repository, profile.github.run_id, `#${profile.github.run_id}`)
-                : "-"
-        const jobLabel = escapeMarkdown(getDisplayValue(profile.github.job, "unknown"))
-        const assertionLabel = escapeMarkdown(getAssertionBadge(profile))
-        const linkLabel = profile.report_link !== "" ? `[View ↗](${escapeMarkdownLink(profile.report_link)})` : "-"
-
-        return `| ${workflowLabel} | ${runLabel} | ${jobLabel} | ${assertionLabel} | ${linkLabel} |`
-    })
-
-    return ["| Workflow | Run | Job | Assertions | Profile |", "| --- | --- | --- | --- | --- |", ...rows].join("\n")
+function renderHeadline(profiles) {
+    return (
+        renderUniqueDestinationHeadline(profiles) ??
+        renderSpawnTopologyHeadline(profiles) ??
+        renderCountsHeadline(profiles)
+    )
 }
 
 /**
- * @param {NormalizedProfile} profile
- * @returns {string}
+ * R1 — a destination reached by exactly one job, computable only when multiple
+ * job profiles are present in the payload.
+ *
+ * @param {NormalizedProfile[]} profiles
+ * @returns {string | null}
  */
-function renderProfileSection(profile) {
-    const title = escapeHtml(formatWorkflowJob(profile.github.workflow, profile.github.job))
-    const assertionBadge = escapeHtml(getAssertionBadge(profile))
-    const workloadTable = renderKeyValueTable([
-        ["Workflow", profile.github.workflow],
-        ["Repository", profile.github.repository],
-        ["Branch", profile.github.ref],
-        ["Commit", profile.github.sha],
-        ["Triggered by", profile.github.actor],
-        ["Run ID / Job", formatRunJob(profile.github.repository, profile.github.run_id, profile.github.job)],
-    ])
-    const networkSection = renderNetworkSection(profile)
-    const assertionSection = renderAssertionSection(profile)
-    const footer = renderProfileFooter(profile)
-
-    return [
-        `<details>`,
-        `<summary><strong>${title}</strong> · ${assertionBadge}</summary>`,
-        "",
-        "#### Workload Summary",
-        "",
-        workloadTable,
-        "",
-        networkSection,
-        "",
-        assertionSection,
-        "",
-        footer,
-        "</details>",
-    ].join("\n")
-}
-
-/**
- * @param {NormalizedProfile} profile
- * @returns {string}
- */
-function renderNetworkSection(profile) {
-    if (!hasNetworkData(profile)) {
-        return [
-            "#### Network Egress Summary",
-            "",
-            "Duplicate egress destinations including their process tree are omitted.",
-            "",
-            "No network information available.",
-        ].join("\n")
+function renderUniqueDestinationHeadline(profiles) {
+    if (profiles.length < 2) {
+        return null
     }
 
-    const rows = []
-    const seen = new Set()
-    let skippedRemoteNames = 0
-    let totalRemoteNames = 0
-
-    for (const peer of profile.egress_peers) {
-        for (const remoteName of peer.remote_names) {
-            totalRemoteNames += 1
-            if (peer.result !== "fail") {
-                if (seen.has(remoteName)) {
-                    skippedRemoteNames += 1
-                    continue
-                }
-                seen.add(remoteName)
+    /** @type {Map<string, Set<string>>} */
+    const destinationJobs = new Map()
+    for (const profile of profiles) {
+        const jobKey = getProfileKey(profile)
+        for (const peer of profile.egress_peers) {
+            for (const remoteName of peer.remote_names) {
+                const jobs = destinationJobs.get(remoteName) ?? new Set()
+                jobs.add(jobKey)
+                destinationJobs.set(remoteName, jobs)
             }
-
-            rows.push([
-                `\`${escapeMarkdown(remoteName)}\``,
-                renderProcessTrees(peer.proc_trees),
-                getResultIcon(peer.result),
-            ])
         }
     }
 
-    const egressTable =
-        rows.length > 0
-            ? renderTable(["Destination", "Process Tree", "Status"], rows)
-            : "No egress peers information available."
+    const uniqueDestinations = [...destinationJobs.entries()]
+        .filter(([, jobs]) => jobs.size === 1)
+        .map(([destination]) => destination)
+        .sort()
 
-    /** @type {[string, string][]} */
-    const telemetryRows = [
-        ["Total egress unique domain(s)", String(profile.telemetry.total_domains)],
-        ["Total egress destination(s)", String(totalRemoteNames)],
-        ["Total egress omitted destination(s)", String(skippedRemoteNames)],
-        ["Total egress connection(s)", String(profile.telemetry.total_connections)],
-        ["Total egress flow(s)", String(profile.egress_peers.length)],
-    ]
+    const destination = uniqueDestinations[0]
+    if (destination === undefined || destinationJobs.size === uniqueDestinations.length) {
+        return null
+    }
 
-    return [
-        "#### Network Egress Summary",
-        "",
-        "Duplicate egress destinations including their process tree are omitted.",
-        "",
-        egressTable,
-        "",
-        "##### Network Telemetry Summary",
-        "",
-        renderKeyValueTable(telemetryRows),
-    ].join("\n")
+    const profile = profiles.find(candidate =>
+        candidate.egress_peers.some(peer => peer.remote_names.includes(destination)),
+    )
+    if (profile === undefined) {
+        return null
+    }
+
+    const jobLabel = getDisplayValue(profile.github.job, "unknown-job")
+    const process = findDestinationProcess(profile, destination)
+    const reachedBy = process !== "" ? `\`${process}\` reached` : "the job reached"
+
+    return `In \`${jobLabel}\`, ${reachedBy} \`${destination}\` — a destination no other job in this run reached.`
+}
+
+/**
+ * R2 — a network tool appearing in the lineage tail of an ancestry array.
+ *
+ * @param {NormalizedProfile[]} profiles
+ * @returns {string | null}
+ */
+function renderSpawnTopologyHeadline(profiles) {
+    for (const profile of profiles) {
+        for (const peer of profile.egress_peers) {
+            for (const procTree of peer.proc_trees) {
+                const toolIndex = findNetworkToolIndex(procTree.ancestry)
+                if (toolIndex === -1) {
+                    continue
+                }
+
+                const jobLabel = getDisplayValue(profile.github.job, "unknown-job")
+                const parent = procTree.ancestry[toolIndex - 1] ?? ""
+                const chain = procTree.ancestry.slice(toolIndex).join(" → ")
+                const destination = peer.remote_names[0] ?? ""
+                const spawnedBy = parent !== "" ? `\`${parent}\` spawned` : "the job spawned"
+                const reached = destination !== "" ? `, which reached \`${destination}\`` : ""
+
+                return `In \`${jobLabel}\`, ${spawnedBy} \`${chain}\`${reached}.`
+            }
+        }
+    }
+
+    return null
+}
+
+/**
+ * R3 — plain job/workflow/destination counts.
+ *
+ * @param {NormalizedProfile[]} profiles
+ * @returns {string}
+ */
+function renderCountsHeadline(profiles) {
+    const jobCount = profiles.length
+    const workflowCount = new Set(profiles.map(profile => getWorkflowKey(profile))).size
+    const domainCount = countUniqueDomains(profiles)
+    const connectionCount = countConnections(profiles)
+
+    if (domainCount === 0 && connectionCount === 0) {
+        return `${pluralize(jobCount, "job")} across ${pluralize(workflowCount, "workflow")} made no outbound connections.`
+    }
+
+    return `${pluralize(jobCount, "job")} across ${pluralize(workflowCount, "workflow")} reached ${pluralize(domainCount, "domain")} over ${pluralize(connectionCount, "connection")}.`
+}
+
+/**
+ * @param {NormalizedProfile[]} profiles
+ * @returns {string}
+ */
+function renderInlineTrees(profiles) {
+    const activeProfiles = profiles.filter(profile => !isQuietProfile(profile))
+    if (activeProfiles.length === 0) {
+        return ""
+    }
+
+    const trees = activeProfiles.map(profile => renderJobTree(profile).join("\n"))
+
+    return ["```text", trees.join("\n\n"), "```"].join("\n")
+}
+
+/**
+ * @param {NormalizedProfile[]} profiles
+ * @returns {string}
+ */
+function renderQuietJobLines(profiles) {
+    return profiles
+        .filter(profile => isQuietProfile(profile))
+        .map(profile => renderQuietJobLine(profile))
+        .join("\n")
 }
 
 /**
  * @param {NormalizedProfile} profile
  * @returns {string}
  */
-function renderAssertionSection(profile) {
-    if (profile.assertions.length === 0) {
-        return ["#### Assertions", "", "No assertions information available."].join("\n")
-    }
+function renderQuietJobLine(profile) {
+    const jobLabel = escapeMarkdown(getDisplayValue(profile.github.job, "unknown-job"))
+    const workflowLabel = escapeMarkdown(getDisplayValue(profile.github.workflow, "unknown-workflow"))
 
-    const rows = profile.assertions.map(assertion => [
-        escapeMarkdown(assertion.id),
-        escapeMarkdown(getResultIconText(assertion.result)),
-    ])
+    return `\`${jobLabel}\` · ${workflowLabel} — made no outbound connections.`
+}
 
-    return ["#### Assertions", "", renderTable(["Check", "Result"], rows)].join("\n")
+/**
+ * @param {NormalizedProfile[]} profiles
+ * @returns {string}
+ */
+function renderEvidenceFold(profiles) {
+    const jobCount = profiles.length
+    const domainCount = countUniqueDomains(profiles)
+    const connectionCount = countConnections(profiles)
+    const summary = `Full process & network evidence · ${pluralize(jobCount, "job")} · ${pluralize(domainCount, "domain")} · ${pluralize(connectionCount, "connection")}`
+    const sections = profiles.map(profile => renderEvidenceSection(profile))
+
+    return ["<details>", `<summary>${summary}</summary>`, "", sections.join("\n\n"), "", "</details>"].join("\n")
 }
 
 /**
  * @param {NormalizedProfile} profile
  * @returns {string}
  */
-function renderProfileFooter(profile) {
-    /** @type {string[]} */
-    const footerParts = []
-    footerParts.push(
-        `${profile.telemetry.total_domains} unique domains · ${profile.telemetry.total_connections} connections`,
-    )
-    if (profile.github.run_id.length > 0 || profile.github.job.length > 0) {
-        footerParts.push(
-            `Workflow ${escapeHtml(getDisplayValue(profile.github.workflow, "-"))} - Run #${escapeHtml(getDisplayValue(profile.github.run_id, "-"))} - Job ${escapeHtml(getDisplayValue(profile.github.job, "-"))}`,
-        )
-    }
-    if (profile.timestamp.length > 0) {
-        footerParts.push(`timestamp ${escapeHtml(profile.timestamp)}`)
+function renderEvidenceSection(profile) {
+    const workflowLabel = escapeMarkdown(getDisplayValue(profile.github.workflow, "unknown-workflow"))
+    const jobLabel = escapeMarkdown(getDisplayValue(profile.github.job, "unknown-job"))
+    const heading = `**${workflowLabel} / ${jobLabel}** · ${pluralize(profile.telemetry.total_domains, "domain")} · ${pluralize(profile.telemetry.total_connections, "connection")}`
+
+    if (isQuietProfile(profile)) {
+        return [heading, "", "Made no outbound connections."].join("\n")
     }
 
-    const header = footerParts.join("  -  ")
-    const viewLink = buildProfileFooterLink(profile.report_link)
-
-    return `<div align="right"><sub>${header}</sub><br><b>Powered by Garnet</b>${viewLink}</div>`
+    return [heading, "", "```text", renderJobTree(profile).join("\n"), "```"].join("\n")
 }
 
 /**
- * @param {ProcTree[]} procTrees
+ * @param {NormalizedProfile[]} profiles
  * @returns {string}
  */
-function renderProcessTrees(procTrees) {
-    const rendered = procTrees
-        .map(procTree => {
-            if (procTree.ancestry.length === 0) {
-                return ""
-            }
+function renderFooter(profiles) {
+    const permalink = profiles.map(profile => profile.report_link).find(link => link !== "") ?? ""
+    const runProfileLink = permalink !== "" ? ` · [Run Profile ↗](${escapeMarkdownLink(permalink)})` : ""
 
-            const [rootProcess, ...remainingAncestry] = procTree.ancestry
-            if (rootProcess === undefined || rootProcess === "") {
-                return ""
-            }
-
-            const items = []
-            items.push(`\`${escapeMarkdown(rootProcess)}\``)
-
-            let start = 1
-            if (procTree.ancestry.length > 4) {
-                start = procTree.ancestry.length - 3
-                items.push("`...`")
-            }
-
-            for (const processName of remainingAncestry.slice(start - 1)) {
-                items.push(`\`${escapeMarkdown(processName)}\``)
-            }
-
-            return items.join(" → ")
-        })
-        .filter(value => value.length > 0)
-
-    return rendered.length > 0 ? rendered.join("<br>") : "-"
+    return `<sub>What happened in this PR — each job's processes and where they reached.${runProfileLink}</sub>`
 }
 
 /**
- * @param {string[]} headers
- * @param {string[][]} rows
- * @returns {string}
+ * @typedef {{
+ *   children: Map<string, LineageNode>
+ *   destinations: Map<string, number>
+ * }} LineageNode
  */
-function renderTable(headers, rows) {
-    const headerRow = `| ${headers.map(header => escapeMarkdown(header)).join(" | ")} |`
-    const separatorRow = `| ${headers.map(() => "---").join(" | ")} |`
-    const bodyRows = rows.map(row => `| ${row.join(" | ")} |`)
-    return [headerRow, separatorRow, ...bodyRows].join("\n")
+
+/**
+ * @returns {LineageNode}
+ */
+function createLineageNode() {
+    return { children: new Map(), destinations: new Map() }
 }
 
 /**
- * @param {[string, string][]} rows
+ * @param {NormalizedProfile} profile
+ * @returns {string[]}
+ */
+function renderJobTree(profile) {
+    const root = createLineageNode()
+
+    for (const peer of profile.egress_peers) {
+        const destinations = peer.remote_names.map(remoteName => formatDestination(remoteName, peer.remote_address ?? ""))
+        const procTrees = peer.proc_trees.filter(procTree => procTree.ancestry.length > 0)
+        const leaves = procTrees.length > 0 ? procTrees.map(procTree => insertLineage(root, procTree.ancestry)) : [root]
+
+        for (const leaf of leaves) {
+            for (const destination of destinations) {
+                leaf.destinations.set(destination, (leaf.destinations.get(destination) ?? 0) + 1)
+            }
+        }
+    }
+
+    const lines = [getDisplayValue(profile.github.job, "unknown-job")]
+    renderLineageNode(root, "", lines)
+    return lines
+}
+
+/**
+ * @param {LineageNode} root
+ * @param {string[]} ancestry
+ * @returns {LineageNode}
+ */
+function insertLineage(root, ancestry) {
+    let node = root
+    for (const processName of ancestry) {
+        let child = node.children.get(processName)
+        if (child === undefined) {
+            child = createLineageNode()
+            node.children.set(processName, child)
+        }
+        node = child
+    }
+
+    return node
+}
+
+/**
+ * @param {LineageNode} node
+ * @param {string} prefix
+ * @param {string[]} lines
+ * @returns {void}
+ */
+function renderLineageNode(node, prefix, lines) {
+    /** @type {{ label: string, child: LineageNode | null }[]} */
+    const entries = []
+    for (const [destination, count] of node.destinations) {
+        entries.push({ label: count > 1 ? `→ ${destination} (×${count})` : `→ ${destination}`, child: null })
+    }
+    for (const [processName, child] of node.children) {
+        entries.push({ label: processName, child })
+    }
+
+    entries.forEach((entry, index) => {
+        const isLast = index === entries.length - 1
+        lines.push(`${prefix}${isLast ? "└─" : "├─"} ${entry.label}`)
+        if (entry.child !== null) {
+            renderLineageNode(entry.child, `${prefix}${isLast ? "   " : "│  "}`, lines)
+        }
+    })
+}
+
+/**
+ * @param {string} remoteName
+ * @param {string} remoteAddress
  * @returns {string}
  */
-function renderKeyValueTable(rows) {
-    return renderTable(
-        ["Field", "Value"],
-        rows.map(([key, value]) => [escapeMarkdown(key), escapeMarkdown(getDisplayValue(value, "-"))]),
-    )
+function formatDestination(remoteName, remoteAddress) {
+    return remoteAddress !== "" ? `${remoteName} · ${remoteAddress}` : remoteName
+}
+
+/**
+ * @param {NormalizedProfile} profile
+ * @param {string} destination
+ * @returns {string}
+ */
+function findDestinationProcess(profile, destination) {
+    for (const peer of profile.egress_peers) {
+        if (!peer.remote_names.includes(destination)) {
+            continue
+        }
+
+        for (const procTree of peer.proc_trees) {
+            const leafProcess = procTree.ancestry.at(-1)
+            if (leafProcess !== undefined && leafProcess !== "") {
+                return leafProcess
+            }
+        }
+    }
+
+    return ""
+}
+
+const NETWORK_TOOLS = new Set(["curl", "wget", "sh -c", "bash -c"])
+const NETWORK_TOOL_TAIL_LENGTH = 3
+
+/**
+ * @param {string[]} ancestry
+ * @returns {number}
+ */
+function findNetworkToolIndex(ancestry) {
+    const tailStart = Math.max(0, ancestry.length - NETWORK_TOOL_TAIL_LENGTH)
+    for (let index = tailStart; index < ancestry.length; index += 1) {
+        const processName = ancestry[index] ?? ""
+        if (NETWORK_TOOLS.has(processName) || NETWORK_TOOLS.has(processName.split(" ")[0] ?? "")) {
+            return index
+        }
+    }
+
+    return -1
+}
+
+/**
+ * @param {NormalizedProfile} profile
+ * @returns {boolean}
+ */
+function isQuietProfile(profile) {
+    return profile.egress_peers.every(peer => peer.remote_names.length === 0) && profile.telemetry.total_connections === 0
+}
+
+/**
+ * @param {NormalizedProfile[]} profiles
+ * @returns {number}
+ */
+function countUniqueDomains(profiles) {
+    const domains = new Set()
+    for (const profile of profiles) {
+        for (const peer of profile.egress_peers) {
+            for (const remoteName of peer.remote_names) {
+                domains.add(remoteName)
+            }
+        }
+    }
+
+    if (domains.size > 0) {
+        return domains.size
+    }
+
+    return profiles.reduce((total, profile) => total + profile.telemetry.total_domains, 0)
+}
+
+/**
+ * @param {NormalizedProfile[]} profiles
+ * @returns {number}
+ */
+function countConnections(profiles) {
+    return profiles.reduce((total, profile) => total + profile.telemetry.total_connections, 0)
+}
+
+/**
+ * @param {number} count
+ * @param {string} noun
+ * @returns {string}
+ */
+function pluralize(count, noun) {
+    return `${count} ${noun}${count === 1 ? "" : "s"}`
+}
+
+/**
+ * @param {string} sha
+ * @returns {string}
+ */
+function shortSha(sha) {
+    return sha.length > 7 ? sha.slice(0, 7) : sha
 }
 
 /**
@@ -735,25 +883,6 @@ function utmTrackedURL(rawURL) {
 }
 
 /**
- * @param {string} repository
- * @param {string} runId
- * @returns {string}
- */
-function buildGitHubRunLink(repository, runId) {
-    const repositoryPath = repository
-        .split("/")
-        .filter(part => part !== "")
-        .map(part => encodeURIComponent(part))
-        .join("/")
-
-    if (repositoryPath === "" || !repositoryPath.includes("/") || runId === "") {
-        return ""
-    }
-
-    return `https://github.com/${repositoryPath}/actions/runs/${encodeURIComponent(runId)}`
-}
-
-/**
  * @returns {string}
  */
 function resolveAppBaseUrl() {
@@ -802,81 +931,6 @@ function mapApiHostToAppHost(host) {
     }
 
     return host
-}
-
-/**
- * @param {NormalizedProfile} profile
- * @returns {"passed" | "attention" | "failed"}
- */
-function getAssertionState(profile) {
-    if (profile.assertions.some(assertion => assertion.result === "fail")) {
-        return "failed"
-    }
-    if (profile.assertions.some(assertion => assertion.result === "attention")) {
-        return "attention"
-    }
-    return "passed"
-}
-
-/**
- * @param {NormalizedProfile} profile
- * @returns {string}
- */
-function getAssertionBadge(profile) {
-    const state = getAssertionState(profile)
-    if (state === "failed") {
-        return "🛑 Failed"
-    }
-    if (state === "attention") {
-        return "🔍 Attention"
-    }
-    return "✅ Passed"
-}
-
-/**
- * @param {NormalizedProfile} profile
- * @returns {boolean}
- */
-function hasNetworkData(profile) {
-    return (
-        profile.egress_peers.length > 0 ||
-        profile.telemetry.total_domains > 0 ||
-        profile.telemetry.total_connections > 0
-    )
-}
-
-/**
- * @param {ProfileResult} result
- * @returns {string}
- */
-function getResultIcon(result) {
-    if (result === "fail") {
-        return "🛑"
-    }
-    if (result === "attention") {
-        return "🔍"
-    }
-    if (result === "pass") {
-        return "✅"
-    }
-    return "❓"
-}
-
-/**
- * @param {ProfileResult} result
- * @returns {string}
- */
-function getResultIconText(result) {
-    if (result === "fail") {
-        return "🛑 Failed"
-    }
-    if (result === "attention") {
-        return "🔍 Attention"
-    }
-    if (result === "pass") {
-        return "✅ Passed"
-    }
-    return "❓ Unknown"
 }
 
 /**
@@ -950,15 +1004,6 @@ function compareProfiles(left, right) {
 }
 
 /**
- * @param {string} workflow
- * @param {string} job
- * @returns {string}
- */
-function formatWorkflowJob(workflow, job) {
-    return `${getDisplayValue(workflow, "Unknown workflow")} / ${getDisplayValue(job, "Unknown job")}`
-}
-
-/**
  * @param {string} value
  * @returns {bigint}
  */
@@ -1018,58 +1063,12 @@ function getProfileNetworkTelemetry(profile) {
 }
 
 /**
- * @param {string} reportLink
- * @returns {string}
- */
-function buildProfileFooterLink(reportLink) {
-    if (reportLink === "") {
-        return ""
-    }
-
-    return ` · <a href="${escapeHtmlAttribute(reportLink)}">View full report ↗</a>`
-}
-
-/**
  * @param {string} value
  * @param {string} fallback
  * @returns {string}
  */
 function getDisplayValue(value, fallback) {
     return value !== "" ? value : fallback
-}
-
-/**
- * @param {string} repository
- * @param {string} runId
- * @param {string} label
- * @returns {string}
- */
-function formatRunMarkdownLink(repository, runId, label) {
-    const runLink = buildGitHubRunLink(repository, runId)
-    if (runLink === "") {
-        return escapeMarkdown(label)
-    }
-
-    return `[${escapeMarkdown(label)}](${escapeMarkdownLink(runLink)})`
-}
-
-/**
- * @param {string} repository
- * @param {string} runId
- * @param {string} job
- * @returns {string}
- */
-function formatRunJob(repository, runId, job) {
-    /** @type {string[]} */
-    const parts = []
-    if (runId !== "") {
-        parts.push(formatRunMarkdownLink(repository, runId, runId))
-    }
-    if (job !== "") {
-        parts.push(escapeMarkdown(job))
-    }
-
-    return parts.length > 0 ? parts.join(" / ") : "-"
 }
 
 /**
@@ -1096,18 +1095,3 @@ function escapeMarkdownLink(value) {
     return value.replaceAll(")", "%29")
 }
 
-/**
- * @param {string} value
- * @returns {string}
- */
-function escapeHtml(value) {
-    return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;")
-}
-
-/**
- * @param {string} value
- * @returns {string}
- */
-function escapeHtmlAttribute(value) {
-    return escapeHtml(value)
-}

--- a/src/profile-comment.js
+++ b/src/profile-comment.js
@@ -25,13 +25,23 @@ const COMMENT_STATE_MARKER_PREFIX = "garnet-action-comment-state:"
  */
 
 /**
- * @typedef {{ ancestry: string[] }} ProcTree
+ * @typedef {{ ancestry: string[], github_step?: string | undefined }} ProcTree
  */
 
 /**
  * @typedef {{
- *   remote_address?: string
+ *   org?: string | undefined
+ *   city?: string | undefined
+ *   country_code?: string | undefined
+ * }} PeerGeoInfo
+ */
+
+/**
+ * @typedef {{
+ *   remote_address?: string | undefined
  *   remote_names: string[]
+ *   remote_ports?: (string | number)[] | undefined
+ *   remote_geo_info?: PeerGeoInfo | undefined
  *   proc_trees: ProcTree[]
  *   result: ProfileResult
  * }} EgressPeer
@@ -95,9 +105,11 @@ const PROFILE_RESULT_SCHEMA = z.unknown().transform(value => normalizeResult(val
 const PROC_TREE_SCHEMA = z
     .looseObject({
         ancestry: z.array(z.string()),
+        github_step: z.string().optional(),
     })
     .transform(procTree => ({
         ancestry: procTree.ancestry.filter(entry => entry.length > 0),
+        ...(procTree.github_step !== undefined ? { github_step: procTree.github_step } : {}),
     }))
 
 const ASSERTION_SCHEMA = z.looseObject({
@@ -105,11 +117,19 @@ const ASSERTION_SCHEMA = z.looseObject({
     result: PROFILE_RESULT_SCHEMA,
 })
 
+const PEER_GEO_INFO_SCHEMA = z.looseObject({
+    org: z.string().optional(),
+    city: z.string().optional(),
+    country_code: z.string().optional(),
+})
+
 const PEER_SCHEMA = z
     .looseObject({
         result: PROFILE_RESULT_SCHEMA,
         remote_address: z.string().optional(),
         remote_names: z.array(z.string()),
+        remote_ports: z.array(z.union([z.string(), z.number()])).optional(),
+        remote_geo_info: PEER_GEO_INFO_SCHEMA.optional(),
         proc_trees: z.array(PROC_TREE_SCHEMA),
     })
     .transform(peer => ({
@@ -117,6 +137,8 @@ const PEER_SCHEMA = z
         remote_names: peer.remote_names.filter(name => name.length > 0),
         proc_trees: peer.proc_trees,
         result: peer.result,
+        ...(peer.remote_ports !== undefined ? { remote_ports: peer.remote_ports } : {}),
+        ...(peer.remote_geo_info !== undefined ? { remote_geo_info: peer.remote_geo_info } : {}),
     }))
 
 const GITHUB_SCENARIO_SCHEMA = z.object({
@@ -375,23 +397,74 @@ export function renderCommentBody(state) {
         `<!-- ${ACTION_COMMENT_MARKER} -->`,
         `<!-- ${COMMIT_MARKER_PREFIX}${commitSha} -->`,
         `<!-- ${COMMENT_STATE_MARKER_PREFIX}${metadata} -->`,
-        "## Garnet Runtime Review",
-        renderMetaLine(profiles),
+        "## What this PR did at runtime",
         "",
-        renderHeadline(profiles),
     ]
 
-    const inlineTrees = renderInlineTrees(profiles)
-    if (inlineTrees !== "") {
-        parts.push("", inlineTrees)
+    if (profiles.length === 0) {
+        parts.push("No runtime activity was recorded for this commit.")
+        return parts.join("\n")
     }
 
-    const quietJobLines = renderQuietJobLines(profiles)
-    if (quietJobLines !== "") {
-        parts.push("", quietJobLines)
+    const totalConnections = profiles.reduce((total, profile) => total + profile.telemetry.total_connections, 0)
+    const uniqueDomains = new Set()
+    for (const profile of profiles) {
+        for (const peer of visiblePeers(profile)) {
+            uniqueDomains.add(lc(destinationName(peer)))
+        }
+    }
+    const totalDomains =
+        uniqueDomains.size > 0
+            ? uniqueDomains.size
+            : profiles.reduce((total, profile) => total + profile.telemetry.total_domains, 0)
+    const workloadDomains = new Set()
+    for (const profile of profiles) {
+        for (const peer of visiblePeers(profile)) {
+            const name = destinationName(peer)
+            if (!isInfraEgress(name)) {
+                workloadDomains.add(lc(name))
+            }
+        }
     }
 
-    parts.push("", renderEvidenceFold(profiles), "", "---", renderFooter(profiles))
+    parts.push(
+        renderSummaryLine({
+            jobs: profiles.length,
+            connections: totalConnections,
+            destinations: totalDomains,
+            workloadDestinations: workloadDomains.size,
+        }),
+        "",
+    )
+
+    // Each job with workload egress gets its own section, one bullet per unique
+    // process lineage. Registry/build-infra egress folds into one deduped block
+    // below, so the comment stays short even on a many-job PR.
+    for (const profile of profiles) {
+        const workload = visiblePeers(profile).filter(peer => !isInfraEgress(destinationName(peer)))
+        if (workload.length === 0) {
+            continue
+        }
+
+        parts.push(`**${escapeMarkdown(profileJobLabel(profile))}** · ${renderJobLinks(profile)}`, "")
+        for (const bullet of renderLineageBullets(workload)) {
+            parts.push(bullet)
+        }
+        parts.push("")
+    }
+
+    const infraBlock = renderInfraBlock(profiles)
+    if (infraBlock.length > 0) {
+        parts.push(...infraBlock, "")
+    }
+
+    const sha = shortSha(commitSha)
+    const reportLink = profiles.map(profile => profile.report_link).find(link => link !== "") ?? ""
+    const linkPart = reportLink !== "" ? ` · <a href="${escapeMarkdownLink(reportLink)}">full runtime record ↗</a>` : ""
+    parts.push(
+        "---",
+        `<sub>${pluralize(totalDomains, "destination")} · ${pluralize(totalConnections, "connection")} across ${pluralize(profiles.length, "job")}${sha !== "" ? ` · \`${sha}\`` : ""} · <b>Powered by Garnet</b>${linkPart}</sub>`,
+    )
 
     return parts.join("\n")
 }
@@ -424,373 +497,368 @@ export function parseCommentState(body) {
 }
 
 /**
- * @param {NormalizedProfile[]} profiles
+ * Package registries & build infrastructure: a FIXED, deterministic list of
+ * well-known package registries, source hosts, OS mirrors, and the runtime's
+ * own plumbing. Used only to group the snapshot so registry noise folds into
+ * one collapsed block — a factual classification, never a judgment. There is
+ * no baseline and no history: the same profile always renders the same comment.
+ */
+const INFRA_EGRESS = [
+    /(^|\.)npmjs\.(org|com)$/,
+    /(^|\.)yarnpkg\.com$/,
+    /(^|\.)pypi\.org$/,
+    /(^|\.)pythonhosted\.org$/,
+    /(^|\.)github\.com$/,
+    /(^|\.)githubusercontent\.com$/,
+    /(^|\.)ghcr\.io$/,
+    /(^|\.)deb\.debian\.org$/,
+    /(^|\.)(archive|security)\.ubuntu\.com$/,
+    /(^|\.)dl\.google\.com$/,
+    /(^|\.)(proxy|sum)\.golang\.org$/,
+    /(^|\.)(static\.)?crates\.io$/,
+    // The runtime's own plumbing: the Garnet sensor's control-plane endpoint
+    // and the GitHub-hosted runner watchdog. Part of running CI, not the PR's
+    // workload.
+    /(^|\.)garnet\.ai$/,
+    /(^|\.)githubapp\.com$/,
+    /hosted-compute-watchdog/,
+]
+
+/**
+ * @param {string} value
  * @returns {string}
  */
-function renderMetaLine(profiles) {
-    const repository = getDisplayValue(profiles[0]?.github.repository ?? "", "unknown-repository")
-    const sha = shortSha(getCommentCommitSha(profiles))
-    const jobCount = profiles.length
-    const workflowCount = new Set(profiles.map(profile => getWorkflowKey(profile))).size
-
-    return `${repository} · ${getDisplayValue(sha, "unknown-commit")} · ${pluralize(jobCount, "job")} · ${pluralize(workflowCount, "workflow")}`
+function lc(value) {
+    return value.trim().toLowerCase()
 }
 
 /**
- * @param {NormalizedProfile[]} profiles
+ * @param {string} name
+ * @returns {boolean}
+ */
+function isInfraEgress(name) {
+    const normalized = lc(name)
+    return INFRA_EGRESS.some(pattern => pattern.test(normalized))
+}
+
+/**
+ * Pick the most human-meaningful name for a destination: prefer a DNS name
+ * over a bare IP.
+ *
+ * @param {EgressPeer} peer
  * @returns {string}
  */
-function renderHeadline(profiles) {
-    return (
-        renderUniqueDestinationHeadline(profiles) ??
-        renderSpawnTopologyHeadline(profiles) ??
-        renderCountsHeadline(profiles)
+function destinationName(peer) {
+    const dns = peer.remote_names.find(name => /[a-z]/i.test(name) && !/^\d+\.\d+\.\d+\.\d+$/.test(name))
+    if (dns !== undefined) {
+        return dns
+    }
+
+    return peer.remote_names[0] ?? peer.remote_address ?? "an unknown host"
+}
+
+/**
+ * @param {EgressPeer} peer
+ * @returns {string}
+ */
+function destinationIP(peer) {
+    const ip = peer.remote_names.find(name => /^\d+\.\d+\.\d+\.\d+$/.test(name))
+    return ip ?? peer.remote_address ?? ""
+}
+
+/**
+ * Loopback / localhost "peers" are not real outbound egress — they're the
+ * local DNS resolver and same-host traffic Jibril also records.
+ *
+ * @param {EgressPeer} peer
+ * @returns {boolean}
+ */
+function isLoopbackPeer(peer) {
+    const names = [...peer.remote_names, peer.remote_address ?? ""].map(lc)
+    return names.some(
+        name => name === "localhost" || name === "::1" || /^127\./.test(name) || /(^|\.)localhost$/.test(name),
     )
 }
 
 /**
- * R1 — a destination reached by exactly one job, computable only when multiple
- * job profiles are present in the payload.
+ * Peers worth rendering: real outbound egress with a resolvable destination.
  *
- * @param {NormalizedProfile[]} profiles
- * @returns {string | null}
+ * @param {NormalizedProfile} profile
+ * @returns {EgressPeer[]}
  */
-function renderUniqueDestinationHeadline(profiles) {
-    if (profiles.length < 2) {
-        return null
-    }
-
-    /** @type {Map<string, Set<string>>} */
-    const destinationJobs = new Map()
-    for (const profile of profiles) {
-        const jobKey = getProfileKey(profile)
-        for (const peer of profile.egress_peers) {
-            for (const remoteName of peer.remote_names) {
-                const jobs = destinationJobs.get(remoteName) ?? new Set()
-                jobs.add(jobKey)
-                destinationJobs.set(remoteName, jobs)
-            }
-        }
-    }
-
-    const uniqueDestinations = [...destinationJobs.entries()]
-        .filter(([, jobs]) => jobs.size === 1)
-        .map(([destination]) => destination)
-        .sort()
-
-    const destination = uniqueDestinations[0]
-    if (destination === undefined || destinationJobs.size === uniqueDestinations.length) {
-        return null
-    }
-
-    const profile = profiles.find(candidate =>
-        candidate.egress_peers.some(peer => peer.remote_names.includes(destination)),
-    )
-    if (profile === undefined) {
-        return null
-    }
-
-    const jobLabel = getDisplayValue(profile.github.job, "unknown-job")
-    const process = findDestinationProcess(profile, destination)
-    const reachedBy = process !== "" ? `\`${process}\` reached` : "the job reached"
-
-    return `In \`${jobLabel}\`, ${reachedBy} \`${destination}\` — a destination no other job in this run reached.`
+function visiblePeers(profile) {
+    return profile.egress_peers.filter(peer => !isLoopbackPeer(peer) && destinationName(peer) !== "an unknown host")
 }
 
 /**
- * R2 — a network tool appearing in the lineage tail of an ancestry array.
+ * First non-empty ancestry recorded for a peer.
  *
- * @param {NormalizedProfile[]} profiles
- * @returns {string | null}
- */
-function renderSpawnTopologyHeadline(profiles) {
-    for (const profile of profiles) {
-        for (const peer of profile.egress_peers) {
-            for (const procTree of peer.proc_trees) {
-                const toolIndex = findNetworkToolIndex(procTree.ancestry)
-                if (toolIndex === -1) {
-                    continue
-                }
-
-                const jobLabel = getDisplayValue(profile.github.job, "unknown-job")
-                const parent = procTree.ancestry[toolIndex - 1] ?? ""
-                const chain = procTree.ancestry.slice(toolIndex).join(" → ")
-                const destination = peer.remote_names[0] ?? ""
-                const spawnedBy = parent !== "" ? `\`${parent}\` spawned` : "the job spawned"
-                const reached = destination !== "" ? `, which reached \`${destination}\`` : ""
-
-                return `In \`${jobLabel}\`, ${spawnedBy} \`${chain}\`${reached}.`
-            }
-        }
-    }
-
-    return null
-}
-
-/**
- * R3 — plain job/workflow/destination counts.
- *
- * @param {NormalizedProfile[]} profiles
- * @returns {string}
- */
-function renderCountsHeadline(profiles) {
-    const jobCount = profiles.length
-    const workflowCount = new Set(profiles.map(profile => getWorkflowKey(profile))).size
-    const domainCount = countUniqueDomains(profiles)
-    const connectionCount = countConnections(profiles)
-
-    if (domainCount === 0 && connectionCount === 0) {
-        return `${pluralize(jobCount, "job")} across ${pluralize(workflowCount, "workflow")} made no outbound connections.`
-    }
-
-    return `${pluralize(jobCount, "job")} across ${pluralize(workflowCount, "workflow")} reached ${pluralize(domainCount, "domain")} over ${pluralize(connectionCount, "connection")}.`
-}
-
-/**
- * @param {NormalizedProfile[]} profiles
- * @returns {string}
- */
-function renderInlineTrees(profiles) {
-    const activeProfiles = profiles.filter(profile => !isQuietProfile(profile))
-    if (activeProfiles.length === 0) {
-        return ""
-    }
-
-    const trees = activeProfiles.map(profile => renderJobTree(profile).join("\n"))
-
-    return ["```text", trees.join("\n\n"), "```"].join("\n")
-}
-
-/**
- * @param {NormalizedProfile[]} profiles
- * @returns {string}
- */
-function renderQuietJobLines(profiles) {
-    return profiles
-        .filter(profile => isQuietProfile(profile))
-        .map(profile => renderQuietJobLine(profile))
-        .join("\n")
-}
-
-/**
- * @param {NormalizedProfile} profile
- * @returns {string}
- */
-function renderQuietJobLine(profile) {
-    const jobLabel = escapeMarkdown(getDisplayValue(profile.github.job, "unknown-job"))
-    const workflowLabel = escapeMarkdown(getDisplayValue(profile.github.workflow, "unknown-workflow"))
-
-    return `\`${jobLabel}\` · ${workflowLabel} — made no outbound connections.`
-}
-
-/**
- * @param {NormalizedProfile[]} profiles
- * @returns {string}
- */
-function renderEvidenceFold(profiles) {
-    const jobCount = profiles.length
-    const domainCount = countUniqueDomains(profiles)
-    const connectionCount = countConnections(profiles)
-    const summary = `Full process & network evidence · ${pluralize(jobCount, "job")} · ${pluralize(domainCount, "domain")} · ${pluralize(connectionCount, "connection")}`
-    const sections = profiles.map(profile => renderEvidenceSection(profile))
-
-    return ["<details>", `<summary>${summary}</summary>`, "", sections.join("\n\n"), "", "</details>"].join("\n")
-}
-
-/**
- * @param {NormalizedProfile} profile
- * @returns {string}
- */
-function renderEvidenceSection(profile) {
-    const workflowLabel = escapeMarkdown(getDisplayValue(profile.github.workflow, "unknown-workflow"))
-    const jobLabel = escapeMarkdown(getDisplayValue(profile.github.job, "unknown-job"))
-    const heading = `**${workflowLabel} / ${jobLabel}** · ${pluralize(profile.telemetry.total_domains, "domain")} · ${pluralize(profile.telemetry.total_connections, "connection")}`
-
-    if (isQuietProfile(profile)) {
-        return [heading, "", "Made no outbound connections."].join("\n")
-    }
-
-    return [heading, "", "```text", renderJobTree(profile).join("\n"), "```"].join("\n")
-}
-
-/**
- * @param {NormalizedProfile[]} profiles
- * @returns {string}
- */
-function renderFooter(profiles) {
-    const permalink = profiles.map(profile => profile.report_link).find(link => link !== "") ?? ""
-    const runProfileLink = permalink !== "" ? ` · [Run Profile ↗](${escapeMarkdownLink(permalink)})` : ""
-
-    return `<sub>What happened in this PR — each job's processes and where they reached.${runProfileLink}</sub>`
-}
-
-/**
- * @typedef {{
- *   children: Map<string, LineageNode>
- *   destinations: Map<string, number>
- * }} LineageNode
- */
-
-/**
- * @returns {LineageNode}
- */
-function createLineageNode() {
-    return { children: new Map(), destinations: new Map() }
-}
-
-/**
- * @param {NormalizedProfile} profile
+ * @param {EgressPeer} peer
  * @returns {string[]}
  */
-function renderJobTree(profile) {
-    const root = createLineageNode()
-
-    for (const peer of profile.egress_peers) {
-        const destinations = peer.remote_names.map(remoteName => formatDestination(remoteName, peer.remote_address ?? ""))
-        const procTrees = peer.proc_trees.filter(procTree => procTree.ancestry.length > 0)
-        const leaves = procTrees.length > 0 ? procTrees.map(procTree => insertLineage(root, procTree.ancestry)) : [root]
-
-        for (const leaf of leaves) {
-            for (const destination of destinations) {
-                leaf.destinations.set(destination, (leaf.destinations.get(destination) ?? 0) + 1)
-            }
+function lineageOf(peer) {
+    for (const procTree of peer.proc_trees) {
+        if (procTree.ancestry.length > 0) {
+            return procTree.ancestry
         }
     }
 
-    const lines = [getDisplayValue(profile.github.job, "unknown-job")]
-    renderLineageNode(root, "", lines)
-    return lines
+    return []
 }
 
 /**
- * @param {LineageNode} root
- * @param {string[]} ancestry
- * @returns {LineageNode}
- */
-function insertLineage(root, ancestry) {
-    let node = root
-    for (const processName of ancestry) {
-        let child = node.children.get(processName)
-        if (child === undefined) {
-            child = createLineageNode()
-            node.children.set(processName, child)
-        }
-        node = child
-    }
-
-    return node
-}
-
-/**
- * @param {LineageNode} node
- * @param {string} prefix
- * @param {string[]} lines
- * @returns {void}
- */
-function renderLineageNode(node, prefix, lines) {
-    /** @type {{ label: string, child: LineageNode | null }[]} */
-    const entries = []
-    for (const [destination, count] of node.destinations) {
-        entries.push({ label: count > 1 ? `→ ${destination} (×${count})` : `→ ${destination}`, child: null })
-    }
-    for (const [processName, child] of node.children) {
-        entries.push({ label: processName, child })
-    }
-
-    entries.forEach((entry, index) => {
-        const isLast = index === entries.length - 1
-        lines.push(`${prefix}${isLast ? "└─" : "├─"} ${entry.label}`)
-        if (entry.child !== null) {
-            renderLineageNode(entry.child, `${prefix}${isLast ? "   " : "│  "}`, lines)
-        }
-    })
-}
-
-/**
- * @param {string} remoteName
- * @param {string} remoteAddress
+ * Reviewer-friendly lineage: keep the root and the last few meaningful hops,
+ * collapsing the noisy middle so a long CI ancestry stays one readable line
+ * (e.g. `systemd → … → bash → node`).
+ *
+ * @param {string[]} lineage
  * @returns {string}
  */
-function formatDestination(remoteName, remoteAddress) {
-    return remoteAddress !== "" ? `${remoteName} · ${remoteAddress}` : remoteName
+function lineageDisplay(lineage) {
+    if (lineage.length <= 5) {
+        return lineage.join(" → ")
+    }
+
+    return [lineage[0], "…", ...lineage.slice(-3)].join(" → ")
 }
 
 /**
- * @param {NormalizedProfile} profile
- * @param {string} destination
+ * Strip GitHub's step-number prefix: "3. Install dependencies" → "Install dependencies".
+ *
+ * @param {string} step
  * @returns {string}
  */
-function findDestinationProcess(profile, destination) {
-    for (const peer of profile.egress_peers) {
-        if (!peer.remote_names.includes(destination)) {
-            continue
-        }
+function cleanStep(step) {
+    return step.replace(/^\s*\d+\.\s*/, "").trim()
+}
 
-        for (const procTree of peer.proc_trees) {
-            const leafProcess = procTree.ancestry.at(-1)
-            if (leafProcess !== undefined && leafProcess !== "") {
-                return leafProcess
-            }
+/**
+ * @param {EgressPeer} peer
+ * @returns {string}
+ */
+function peerStep(peer) {
+    for (const procTree of peer.proc_trees) {
+        const step = cleanStep(procTree.github_step ?? "")
+        if (step !== "") {
+            return step
         }
     }
 
     return ""
 }
 
-const NETWORK_TOOLS = new Set(["curl", "wget", "sh -c", "bash -c"])
-const NETWORK_TOOL_TAIL_LENGTH = 3
-
 /**
- * @param {string[]} ancestry
- * @returns {number}
+ * Compact "who is on the other end" label from Jibril's geo enrichment, e.g.
+ * "Cloudflare, Inc. · Toronto, CA". Purely descriptive. Empty when no geo is
+ * present.
+ *
+ * @param {EgressPeer} peer
+ * @returns {string}
  */
-function findNetworkToolIndex(ancestry) {
-    const tailStart = Math.max(0, ancestry.length - NETWORK_TOOL_TAIL_LENGTH)
-    for (let index = tailStart; index < ancestry.length; index += 1) {
-        const processName = ancestry[index] ?? ""
-        if (NETWORK_TOOLS.has(processName) || NETWORK_TOOLS.has(processName.split(" ")[0] ?? "")) {
-            return index
-        }
+function hostedByLabel(peer) {
+    const geo = peer.remote_geo_info
+    if (geo === undefined) {
+        return ""
     }
 
-    return -1
+    const owner = (geo.org ?? "").trim()
+    const place = [geo.city, geo.country_code].filter(part => part !== undefined && part !== "").join(", ")
+    return [owner, place].filter(part => part !== "").join(" · ")
+}
+
+/**
+ * Join a list into "a", "a and b", or "a, b, and c".
+ *
+ * @param {string[]} items
+ * @returns {string}
+ */
+function humanList(items) {
+    if (items.length === 0) {
+        return ""
+    }
+    if (items.length === 1) {
+        return items[0] ?? ""
+    }
+    if (items.length === 2) {
+        return `${items[0]} and ${items[1]}`
+    }
+
+    return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`
 }
 
 /**
  * @param {NormalizedProfile} profile
- * @returns {boolean}
+ * @returns {string}
  */
-function isQuietProfile(profile) {
-    return profile.egress_peers.every(peer => peer.remote_names.length === 0) && profile.telemetry.total_connections === 0
+function profileJobLabel(profile) {
+    const workflow = profile.github.workflow
+    const job = profile.github.job
+    if (workflow !== "" && job !== "") {
+        return `${workflow} / ${job}`
+    }
+
+    return getDisplayValue(job !== "" ? job : workflow, "unknown-job")
 }
 
 /**
- * @param {NormalizedProfile[]} profiles
- * @returns {number}
+ * @param {NormalizedProfile} profile
+ * @returns {string}
  */
-function countUniqueDomains(profiles) {
-    const domains = new Set()
-    for (const profile of profiles) {
-        for (const peer of profile.egress_peers) {
-            for (const remoteName of peer.remote_names) {
-                domains.add(remoteName)
-            }
+function renderJobLinks(profile) {
+    const links = []
+    if (profile.github.repository !== "" && profile.github.run_id !== "") {
+        links.push(`[run ↗](https://github.com/${profile.github.repository}/actions/runs/${profile.github.run_id})`)
+    }
+    if (profile.report_link !== "") {
+        links.push(`[details ↗](${escapeMarkdownLink(profile.report_link)})`)
+    }
+
+    return links.join(" · ")
+}
+
+/**
+ * @typedef {{
+ *   display: string
+ *   step: string
+ *   domains: { name: string, ip: string, hostedBy: string }[]
+ * }} LineageGroup
+ */
+
+/**
+ * Group peers by unique process lineage; append all destinations per lineage.
+ *
+ * @param {EgressPeer[]} peers
+ * @returns {LineageGroup[]}
+ */
+function groupByLineage(peers) {
+    /** @type {Map<string, LineageGroup>} */
+    const groups = new Map()
+    for (const peer of peers) {
+        const lineage = lineageOf(peer)
+        const key = lineage.join("\u241f")
+        let group = groups.get(key)
+        if (group === undefined) {
+            group = { display: lineageDisplay(lineage), step: peerStep(peer), domains: [] }
+            groups.set(key, group)
+        }
+        if (group.step === "") {
+            group.step = peerStep(peer)
+        }
+
+        const name = destinationName(peer)
+        if (!group.domains.some(domain => domain.name === name)) {
+            group.domains.push({ name, ip: destinationIP(peer), hostedBy: hostedByLabel(peer) })
         }
     }
 
-    if (domains.size > 0) {
-        return domains.size
+    return [...groups.values()]
+}
+
+const MAX_LINEAGES = 6
+const MAX_DOMAINS = 6
+
+/**
+ * One bullet per unique lineage, destinations appended into a single sentence.
+ * Caps width so a large PR stays readable; the rest lives in Garnet.
+ *
+ * @param {EgressPeer[]} peers
+ * @returns {string[]}
+ */
+function renderLineageBullets(peers) {
+    const groups = groupByLineage(peers)
+    const lines = []
+    for (const group of groups.slice(0, MAX_LINEAGES)) {
+        const shownDomains = group.domains.slice(0, MAX_DOMAINS)
+        // When a lineage reached a single destination, inline who is on the
+        // other end (IP · owner · city) — the reviewer's first question. With
+        // several destinations, keep the names clean.
+        const single = shownDomains.length === 1
+        const shown = shownDomains.map(domain => {
+            const meta = single
+                ? [domain.ip, domain.hostedBy].filter(part => part !== "" && part !== domain.name).map(escapeMarkdown)
+                : []
+            return meta.length > 0
+                ? `\`${escapeMarkdown(domain.name)}\` (${meta.join(" · ")})`
+                : `\`${escapeMarkdown(domain.name)}\``
+        })
+        const extra = group.domains.length > MAX_DOMAINS ? `, and ${group.domains.length - MAX_DOMAINS} more` : ""
+        const step = group.step !== "" ? ` — observed during **${escapeMarkdown(group.step)}**` : ""
+        const display = group.display !== "" ? group.display : "a process"
+        lines.push(`- \`${escapeMarkdown(display)}\` connected to ${humanList(shown)}${extra}${step}`)
+    }
+    if (groups.length > MAX_LINEAGES) {
+        lines.push(`- …and ${groups.length - MAX_LINEAGES} more process lineages`)
     }
 
-    return profiles.reduce((total, profile) => total + profile.telemetry.total_domains, 0)
+    return lines
 }
 
 /**
+ * Collapsed, deduped registry/build-infra block. Folds the package registries
+ * and source hosts across ALL jobs into one short list so the comment shows
+ * the workload egress up top and never repeats npm/GitHub noise per job.
+ *
  * @param {NormalizedProfile[]} profiles
- * @returns {number}
+ * @returns {string[]}
  */
-function countConnections(profiles) {
-    return profiles.reduce((total, profile) => total + profile.telemetry.total_connections, 0)
+function renderInfraBlock(profiles) {
+    /** @type {Map<string, Set<string>>} */
+    const domainJobs = new Map()
+    for (const profile of profiles) {
+        const label = profileJobLabel(profile)
+        for (const peer of visiblePeers(profile)) {
+            const name = destinationName(peer)
+            if (!isInfraEgress(name)) {
+                continue
+            }
+            const jobs = domainJobs.get(name) ?? new Set()
+            jobs.add(label)
+            domainJobs.set(name, jobs)
+        }
+    }
+
+    if (domainJobs.size === 0) {
+        return []
+    }
+
+    const jobs = new Set()
+    for (const set of domainJobs.values()) {
+        for (const job of set) {
+            jobs.add(job)
+        }
+    }
+
+    const rows = [...domainJobs.entries()].sort((left, right) => right[1].size - left[1].size || left[0].localeCompare(right[0]))
+    const lines = [
+        `<details><summary>Package registries & build infrastructure · ${pluralize(domainJobs.size, "destination")} across ${pluralize(jobs.size, "job")}</summary>`,
+        "",
+    ]
+    for (const [domain, set] of rows) {
+        lines.push(`- \`${escapeMarkdown(domain)}\` — ${pluralize(set.size, "job")}`)
+    }
+    lines.push("", "</details>")
+
+    return lines
+}
+
+/**
+ * Opening line — a factual account of the snapshot (counts + where the egress
+ * went), with no judgment attached.
+ *
+ * @param {{ jobs: number, connections: number, destinations: number, workloadDestinations: number }} counts
+ * @returns {string}
+ */
+function renderSummaryLine(counts) {
+    if (counts.connections === 0) {
+        return `This PR's code made **no outbound connections** across ${pluralize(counts.jobs, "CI job")}.`
+    }
+
+    const head = `This PR's code made **${pluralize(counts.connections, "outbound connection")} to ${pluralize(counts.destinations, "destination")}** across ${pluralize(counts.jobs, "CI job")}.`
+    if (counts.workloadDestinations === 0) {
+        return `${head} All of it went to package registries & build infrastructure.`
+    }
+
+    return `${head} Beyond package registries & build infrastructure, its workload connected to ${pluralize(counts.workloadDestinations, "destination")}:`
 }
 
 /**

--- a/src/profile-comment.js
+++ b/src/profile-comment.js
@@ -374,7 +374,7 @@ export function renderCommentBody(state) {
         `<!-- ${ACTION_COMMENT_MARKER} -->`,
         `<!-- ${COMMIT_MARKER_PREFIX}${commitSha} -->`,
         `<!-- ${COMMENT_STATE_MARKER_PREFIX}${metadata} -->`,
-        "## Garnet Runtime Report",
+        "## Garnet Runtime Review",
         "",
         headline,
         "",
@@ -417,14 +417,25 @@ export function parseCommentState(body) {
  */
 function renderHeadline(profiles) {
     const failedJobs = profiles.filter(profile => getAssertionState(profile) === "failed").length
-    const passedJobs = profiles.length - failedJobs
+    const attentionJobs = profiles.filter(profile => getAssertionState(profile) === "attention").length
+    const passedJobs = profiles.length - failedJobs - attentionJobs
     const workflowCount = new Set(profiles.map(profile => getWorkflowKey(profile))).size
+    const across = `across ${workflowCount} workflow${workflowCount === 1 ? "" : "s"}`
 
     if (failedJobs > 0) {
-        return `🔴 ${failedJobs} job${failedJobs === 1 ? "" : "s"} failed assertions · ${passedJobs} passed across ${workflowCount} workflow${workflowCount === 1 ? "" : "s"}`
+        const rest = []
+        if (attentionJobs > 0) {
+            rest.push(`${attentionJobs} attention`)
+        }
+        rest.push(`${passedJobs} passed`)
+        return `🛑 **Failed** — ${failedJobs} job${failedJobs === 1 ? "" : "s"} failed assertions · ${rest.join(" · ")} ${across}`
     }
 
-    return `✅ ${passedJobs} job${passedJobs === 1 ? "" : "s"} passed assertions across ${workflowCount} workflow${workflowCount === 1 ? "" : "s"}`
+    if (attentionJobs > 0) {
+        return `🔍 **Attention** — ${attentionJobs} job${attentionJobs === 1 ? "" : "s"} flagged for attention · ${passedJobs} passed ${across}`
+    }
+
+    return `✅ **Passed** — ${passedJobs} job${passedJobs === 1 ? "" : "s"} passed assertions ${across}`
 }
 
 /**
@@ -795,10 +806,16 @@ function mapApiHostToAppHost(host) {
 
 /**
  * @param {NormalizedProfile} profile
- * @returns {"passed" | "failed"}
+ * @returns {"passed" | "attention" | "failed"}
  */
 function getAssertionState(profile) {
-    return profile.assertions.some(assertion => assertion.result === "fail") ? "failed" : "passed"
+    if (profile.assertions.some(assertion => assertion.result === "fail")) {
+        return "failed"
+    }
+    if (profile.assertions.some(assertion => assertion.result === "attention")) {
+        return "attention"
+    }
+    return "passed"
 }
 
 /**
@@ -806,7 +823,14 @@ function getAssertionState(profile) {
  * @returns {string}
  */
 function getAssertionBadge(profile) {
-    return getAssertionState(profile) === "failed" ? "🔴 Failed" : "✅ Passed"
+    const state = getAssertionState(profile)
+    if (state === "failed") {
+        return "🛑 Failed"
+    }
+    if (state === "attention") {
+        return "🔍 Attention"
+    }
+    return "✅ Passed"
 }
 
 /**
@@ -827,9 +851,12 @@ function hasNetworkData(profile) {
  */
 function getResultIcon(result) {
     if (result === "fail") {
-        return "🔴"
+        return "🛑"
     }
-    if (result === "pass" || result === "attention") {
+    if (result === "attention") {
+        return "🔍"
+    }
+    if (result === "pass") {
         return "✅"
     }
     return "❓"
@@ -841,12 +868,15 @@ function getResultIcon(result) {
  */
 function getResultIconText(result) {
     if (result === "fail") {
-        return "🔴 fail"
+        return "🛑 Failed"
     }
-    if (result === "pass" || result === "attention") {
-        return "✅ pass"
+    if (result === "attention") {
+        return "🔍 Attention"
     }
-    return "❓ unknown"
+    if (result === "pass") {
+        return "✅ Passed"
+    }
+    return "❓ Unknown"
 }
 
 /**

--- a/src/profile-comment.test.js
+++ b/src/profile-comment.test.js
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import {
+    ACTION_COMMENT_MARKER,
+    COMMIT_MARKER_PREFIX,
+    RUNTIME_REVIEW_MARKER,
+    mergeCommentState,
+    parseCommentState,
+    renderCommentBody,
+} from "./profile-comment.js"
+import { planPullRequestComment } from "./pr-comment-plan.js"
+
+/** @typedef {import("./profile-comment.js").NormalizedProfile} NormalizedProfile */
+/** @typedef {import("./profile-comment.js").CommentState} CommentState */
+
+const BANNED_WORDS = [
+    "pass",
+    "passed",
+    "fail",
+    "failed",
+    "attention",
+    "clean",
+    "routine",
+    "usual",
+    "check",
+    "detection",
+    "verdict",
+    "risk",
+    "severity",
+    "threat",
+    "malicious",
+    "suspicious",
+    "block",
+]
+
+const BANNED_GLYPHS = ["🔴", "✅", "⚠", "🛑", "🔍", "❓"]
+
+const BANNED_WORD_PATTERN = new RegExp(`\\b(${BANNED_WORDS.join("|")})\\b`, "i")
+
+/**
+ * @param {Partial<NormalizedProfile["github"]>} github
+ * @param {Partial<NormalizedProfile>} overrides
+ * @returns {NormalizedProfile}
+ */
+function makeProfile(github = {}, overrides = {}) {
+    return {
+        timestamp: "2026-07-01T00:00:00Z",
+        github: {
+            workflow: "CI",
+            repository: "garnet-org/example",
+            ref: "refs/pull/1/merge",
+            sha: "0123456789abcdef0123456789abcdef01234567",
+            actor: "octocat",
+            run_id: "12345",
+            job: "e2e",
+            ...github,
+        },
+        assertions: [
+            { id: "assertion-one", result: "pass" },
+            { id: "assertion-two", result: "fail" },
+        ],
+        egress_peers: [
+            {
+                remote_address: "104.16.10.34",
+                remote_names: ["registry.npmjs.org"],
+                proc_trees: [{ ancestry: ["npm install", "node"] }],
+                result: "pass",
+            },
+            {
+                remote_address: "45.137.21.88",
+                remote_names: ["img-cdn-assets.com"],
+                proc_trees: [{ ancestry: ["npm install", "node", "sh -c", "curl"] }],
+                result: "fail",
+            },
+        ],
+        telemetry: { total_domains: 2, total_connections: 12 },
+        report_link: "https://app.garnet.ai/dashboard/runs/12345?utm_source=github&utm_medium=pr_comment",
+        ...overrides,
+    }
+}
+
+/**
+ * @param {NormalizedProfile[]} profiles
+ * @returns {CommentState}
+ */
+function makeState(profiles) {
+    return {
+        version: 2,
+        workflow_runs: Object.fromEntries(
+            profiles.map(profile => [profile.github.workflow, { run_id: profile.github.run_id, run_attempt: 1 }]),
+        ),
+        profiles,
+    }
+}
+
+/**
+ * @param {string} body
+ * @returns {string}
+ */
+function stripHtmlCommentMarkers(body) {
+    return body.replaceAll(/<!--[\s\S]*?-->/g, "")
+}
+
+function renderFixtureBodies() {
+    return [
+        renderCommentBody(makeState([makeProfile()])),
+        renderCommentBody(
+            makeState([
+                makeProfile(),
+                makeProfile(
+                    { workflow: "Docs", job: "build-docs" },
+                    { egress_peers: [], telemetry: { total_domains: 0, total_connections: 0 } },
+                ),
+            ]),
+        ),
+        renderCommentBody(
+            makeState([
+                makeProfile({}, { egress_peers: [], telemetry: { total_domains: 0, total_connections: 0 } }),
+            ]),
+        ),
+    ]
+}
+
+test("rendered comment contains no banned vocabulary or status glyphs", () => {
+    for (const body of renderFixtureBodies()) {
+        const rendered = stripHtmlCommentMarkers(body)
+        const wordMatch = rendered.match(BANNED_WORD_PATTERN)
+        assert.equal(wordMatch, null, `banned word ${JSON.stringify(wordMatch?.[0])} found in rendered comment`)
+
+        for (const glyph of BANNED_GLYPHS) {
+            assert.ok(!rendered.includes(glyph), `banned glyph ${glyph} found in rendered comment`)
+        }
+    }
+})
+
+test("rendered comment emits runtime-review, action, and commit markers", () => {
+    const body = renderCommentBody(makeState([makeProfile()]))
+
+    assert.ok(body.includes(`<!-- ${RUNTIME_REVIEW_MARKER} -->`))
+    assert.ok(body.includes(`<!-- ${ACTION_COMMENT_MARKER} -->`))
+    assert.ok(body.includes(`<!-- ${COMMIT_MARKER_PREFIX}0123456789abcdef0123456789abcdef01234567 -->`))
+})
+
+test("rendered comment follows the observation-only anatomy", () => {
+    const body = renderCommentBody(
+        makeState([
+            makeProfile(),
+            makeProfile(
+                { workflow: "Docs", job: "build-docs" },
+                { egress_peers: [], telemetry: { total_domains: 0, total_connections: 0 } },
+            ),
+        ]),
+    )
+
+    assert.ok(body.includes("## Garnet Runtime Review"))
+    assert.ok(body.includes("garnet-org/example · 0123456 · 2 jobs · 2 workflows"))
+    assert.ok(body.includes("```text"))
+    assert.ok(body.includes("→ registry.npmjs.org · 104.16.10.34"))
+    assert.ok(body.includes("→ img-cdn-assets.com · 45.137.21.88"))
+    assert.ok(body.includes("`build-docs` · Docs — made no outbound connections."))
+    assert.ok(body.includes("<details>"))
+    assert.ok(body.includes("<summary>Full process & network evidence · 2 jobs · 2 domains · 12 connections</summary>"))
+    assert.ok(!body.includes("| ---"), "evidence fold must not contain markdown tables")
+    assert.ok(body.includes("<sub>What happened in this PR — each job's processes and where they reached."))
+    assert.ok(body.includes("[Run Profile ↗]("))
+    assert.ok(!body.includes("Assertions"), "phase 1 must not render assertions")
+})
+
+test("headline reports spawn topology for a single job profile", () => {
+    const body = renderCommentBody(makeState([makeProfile()]))
+
+    assert.ok(body.includes("In `e2e`, `node` spawned `sh -c → curl`, which reached `img-cdn-assets.com`."))
+})
+
+test("headline reports within-run uniqueness when multiple job profiles exist", () => {
+    const shared = {
+        remote_address: "104.16.10.34",
+        remote_names: ["registry.npmjs.org"],
+        proc_trees: [{ ancestry: ["npm install", "node"] }],
+        result: /** @type {const} */ ("pass"),
+    }
+    const body = renderCommentBody(
+        makeState([
+            makeProfile(),
+            makeProfile(
+                { workflow: "Docs", job: "build-docs" },
+                { egress_peers: [shared], telemetry: { total_domains: 1, total_connections: 3 } },
+            ),
+        ]),
+    )
+
+    assert.ok(body.includes("`img-cdn-assets.com` — a destination no other job in this run reached."))
+})
+
+test("rendered comment state round-trips", () => {
+    const state = makeState([makeProfile()])
+    const body = renderCommentBody(state)
+
+    assert.deepEqual(parseCommentState(body), state)
+})
+
+test("merged profiles re-render deterministically", () => {
+    const profile = makeProfile()
+    const merged = mergeCommentState(null, profile, 1)
+
+    assert.equal(merged.kind, "updated")
+    if (merged.kind === "updated") {
+        assert.equal(renderCommentBody(merged.state), renderCommentBody(merged.state))
+    }
+})
+
+test("action defers to existing control-plane comments", () => {
+    const plan = planPullRequestComment(
+        [{ id: 1, body: "<!-- garnet-control-plane-pr-comment:v1 -->\nsome app comment" }],
+        makeProfile(),
+        1,
+    )
+
+    assert.deepEqual(plan, { kind: "blocked-by-control-plane" })
+})

--- a/src/profile-comment.test.js
+++ b/src/profile-comment.test.js
@@ -141,7 +141,7 @@ test("rendered comment emits runtime-review, action, and commit markers", () => 
     assert.ok(body.includes(`<!-- ${COMMIT_MARKER_PREFIX}0123456789abcdef0123456789abcdef01234567 -->`))
 })
 
-test("rendered comment follows the observation-only anatomy", () => {
+test("rendered comment follows the runtime-snapshot anatomy", () => {
     const body = renderCommentBody(
         makeState([
             makeProfile(),
@@ -152,44 +152,50 @@ test("rendered comment follows the observation-only anatomy", () => {
         ]),
     )
 
-    assert.ok(body.includes("## Garnet Runtime Review"))
-    assert.ok(body.includes("garnet-org/example · 0123456 · 2 jobs · 2 workflows"))
-    assert.ok(body.includes("```text"))
-    assert.ok(body.includes("→ registry.npmjs.org · 104.16.10.34"))
-    assert.ok(body.includes("→ img-cdn-assets.com · 45.137.21.88"))
-    assert.ok(body.includes("`build-docs` · Docs — made no outbound connections."))
-    assert.ok(body.includes("<details>"))
-    assert.ok(body.includes("<summary>Full process & network evidence · 2 jobs · 2 domains · 12 connections</summary>"))
-    assert.ok(!body.includes("| ---"), "evidence fold must not contain markdown tables")
-    assert.ok(body.includes("<sub>What happened in this PR — each job's processes and where they reached."))
-    assert.ok(body.includes("[Run Profile ↗]("))
+    assert.ok(body.includes("## What this PR did at runtime"))
+    assert.ok(
+        body.includes(
+            "This PR's code made **12 outbound connections to 2 destinations** across 2 CI jobs. Beyond package registries & build infrastructure, its workload connected to 1 destination:",
+        ),
+    )
+    assert.ok(body.includes("**CI / e2e** · [run ↗](https://github.com/garnet-org/example/actions/runs/12345)"))
+    assert.ok(body.includes("- `npm install → node → sh -c → curl` connected to `img-cdn-assets.com` (45.137.21.88)"))
+    assert.ok(
+        body.includes("<details><summary>Package registries & build infrastructure · 1 destination across 1 job</summary>"),
+    )
+    assert.ok(body.includes("- `registry.npmjs.org` — 1 job"))
+    assert.ok(body.includes("<b>Powered by Garnet</b>"))
+    assert.ok(body.includes("full runtime record ↗"))
+    assert.ok(body.includes("2 destinations · 12 connections across 2 jobs · `0123456`"))
     assert.ok(!body.includes("Assertions"), "phase 1 must not render assertions")
 })
 
-test("headline reports spawn topology for a single job profile", () => {
-    const body = renderCommentBody(makeState([makeProfile()]))
+test("registry-only run folds everything into the infra block", () => {
+    const registryOnly = makeProfile(
+        {},
+        {
+            egress_peers: [
+                {
+                    remote_address: "104.16.10.34",
+                    remote_names: ["registry.npmjs.org"],
+                    proc_trees: [{ ancestry: ["npm install", "node"] }],
+                    result: /** @type {const} */ ("pass"),
+                },
+            ],
+            telemetry: { total_domains: 1, total_connections: 4 },
+        },
+    )
+    const body = renderCommentBody(makeState([registryOnly]))
 
-    assert.ok(body.includes("In `e2e`, `node` spawned `sh -c → curl`, which reached `img-cdn-assets.com`."))
+    assert.ok(body.includes("All of it went to package registries & build infrastructure."))
+    assert.ok(!body.includes("**CI / e2e** ·"), "registry-only jobs must not get a workload section")
 })
 
-test("headline reports within-run uniqueness when multiple job profiles exist", () => {
-    const shared = {
-        remote_address: "104.16.10.34",
-        remote_names: ["registry.npmjs.org"],
-        proc_trees: [{ ancestry: ["npm install", "node"] }],
-        result: /** @type {const} */ ("pass"),
-    }
-    const body = renderCommentBody(
-        makeState([
-            makeProfile(),
-            makeProfile(
-                { workflow: "Docs", job: "build-docs" },
-                { egress_peers: [shared], telemetry: { total_domains: 1, total_connections: 3 } },
-            ),
-        ]),
-    )
+test("zero-connection run states no outbound connections", () => {
+    const quiet = makeProfile({}, { egress_peers: [], telemetry: { total_domains: 0, total_connections: 0 } })
+    const body = renderCommentBody(makeState([quiet]))
 
-    assert.ok(body.includes("`img-cdn-assets.com` — a destination no other job in this run reached."))
+    assert.ok(body.includes("This PR's code made **no outbound connections** across 1 CI job."))
 })
 
 test("rendered comment state round-trips", () => {


### PR DESCRIPTION
## Summary

Rewrites the action's fallback PR comment (`src/profile-comment.js`) to the LOCKED observation-only "Garnet Runtime Review" spec. The comment now answers only *what happened in this PR* — all verdict/security vocabulary and status glyphs (Passed/Failed/Attention, ✅/🛑/🔍, badges, tables of assertion results) are removed from rendered output.

Rendered anatomy (Phase 1: lineage + egress only — no files, assertions, or detections):

```
<!-- garnet-runtime-review -->
<!-- garnet-action-pr-comment:v1 -->
<!-- garnet-pr-commit:{sha} -->
<!-- garnet-action-comment-state:{base64 state} -->
## Garnet Runtime Review
{repo} · {sha7} · {N} jobs · {M} workflows

{structural salience headline}

```text
{job}
└─ npm install
   └─ node
      ├─ → registry.npmjs.org · 104.16.10.34
      └─ sh -c
         └─ curl
            └─ → img-cdn-assets.com · 45.137.21.88
```

`build-docs` · Docs — made no outbound connections.

<details><summary>Full process & network evidence · N jobs · D domains · C connections</summary>
{per-job text-fenced trees — no markdown tables}
</details>

---
<sub>What happened in this PR — each job's processes and where they reached. · [Run Profile ↗](permalink)</sub>
```

Headline ranking (facts only, never an evaluation):
- **R1** — destination reached by exactly one job; only computed when the merged comment state contains multiple job profiles, and skipped when *every* destination is single-job (uniqueness isn't salient then).
- **R2** — network tool (`curl`/`wget`/`sh -c`/`bash -c`) in the lineage tail (last 3 ancestry entries): ``In `e2e`, `node` spawned `sh -c → curl`, which reached `img-cdn-assets.com`.``
- **R3** — plain counts fallback.

Trees are shared-prefix-merged per job from `peer.proc_trees[].ancestry`, leaf-annotated `→ domain · ip` (per-leaf `(×N)` dedup counts). `PEER_SCHEMA` now optionally carries `remote_address` for the ip annotation. Deterministic: same payload → same comment.

### Markers & suppression (spec §8)
- The action's comment now emits `<!-- garnet-runtime-review -->` **in addition to** `garnet-action-pr-comment:v1`, `garnet-pr-commit:{sha}`, and the base64 state marker. The legacy `garnet-runtime-visibility:{state}` marker is no longer emitted; the reader path for it remains in `parseCommentState`.
- **`containsControlPlaneComment` intentionally stays keyed on the control-plane v1 markers only** (`garnet-control-plane-pr-comment:v1` / `garnet-control-plane-pending-pr-comment:v1`). The new `garnet-runtime-review` marker is shared across surfaces — the action's own comments contain it too — so treating "any comment containing `garnet-runtime-review`" as "the App has commented" is not reliably distinguishable and would make the action suppress itself. Since the App continues to emit its v1 markers alongside the new marker (spec §8), v1-marker detection remains a complete signal for App presence; App-primary / action-fallback precedence is preserved across mixed versions.

### Step summary path
`src/post.js` behavior is unchanged — it appends Jibril's markdown to `GITHUB_STEP_SUMMARY` as before; only action-owned rendered strings changed.

### Tests / CI gate (spec §10)
- New `src/profile-comment.test.js` (node:test): banned-vocabulary + glyph gate over rendered fixture comments (HTML comment markers stripped before scanning, since base64 state can contain arbitrary word-boundary substrings), anatomy assertions (markers, meta line, quiet-job one-liners, no markdown tables in the fold, no assertions rendered), R1/R2 headline cases, state round-trip, determinism, and control-plane deferral.
- `npm run test` (`node --test src/`) added to `package.json` and wired into CI before the build step; `validate` runs typecheck + test + build.
- `dist/` rebuilt via `npm run build` (pre-commit hook) and committed.


Link to Devin session: https://app.devin.ai/sessions/29b127da716847238a18175863cbe46c
Requested by: @jadoonf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/garnet-org/action/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->