### PR TITLE
test: allow skipping gh app comment

### DIFF
--- a/.github/workflows/pr-comment-smoke-test-a-and-b.yaml
+++ b/.github/workflows/pr-comment-smoke-test-a-and-b.yaml
@@ -42,6 +42,11 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v7
 
+            - name: Enable internal skip-comment mode
+              if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skip-github-app-comment')
+              shell: bash
+              run: echo "GARNET_ACTION_SKIP_GITHUB_APP_COMMENT=true" >> "$GITHUB_ENV"
+
             - name: Run Garnet
               uses: ./
               with:
@@ -96,6 +101,11 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v7
+
+            - name: Enable internal skip-comment mode
+              if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skip-github-app-comment')
+              shell: bash
+              run: echo "GARNET_ACTION_SKIP_GITHUB_APP_COMMENT=true" >> "$GITHUB_ENV"
 
             - name: Run Garnet
               uses: ./

--- a/.github/workflows/pr-comment-smoke-test-c.yaml
+++ b/.github/workflows/pr-comment-smoke-test-c.yaml
@@ -42,6 +42,11 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v7
 
+            - name: Enable internal skip-comment mode
+              if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skip-github-app-comment')
+              shell: bash
+              run: echo "GARNET_ACTION_SKIP_GITHUB_APP_COMMENT=true" >> "$GITHUB_ENV"
+
             - name: Run Garnet
               uses: ./
               with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Avoid third-party libraries whenever possible.
 - Always ask before introducing any new dependency.
 - Write idiomatic, easy-to-read, self-documenting code.
+- Prefer straightforward control flow (`if` statements and intermediate variables) over clever inline expressions/spreads when constructing objects.
 - Prefer explicit checks; do not rely on truthy/falsy comparisons.
 - Handle errors at all I/O, process, and network boundaries.
 - Favor strict, safe code (validate external input and fail clearly).

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -39094,6 +39094,7 @@ function preprocess(fn, schema) {
  *   machine_id: string
  *   kind: "github" | "kubernetes"
  *   github_context?: AgentGithubContext
+ *   labels?: Record<string, string>
  * }} CreateAgentRequest
  */
 
@@ -39140,6 +39141,7 @@ const CREATE_AGENT_REQUEST_SCHEMA = object({
     machine_id: schemas_string().min(1),
     kind: schemas_enum(["github", "kubernetes"]),
     github_context: AGENT_GITHUB_CONTEXT_SCHEMA.optional(),
+    labels: record(schemas_string(), schemas_string()).optional(),
 })
 
 const AGENT_CREATED_RESPONSE_SCHEMA = object({
@@ -39565,6 +39567,10 @@ async function run() {
         const AGENT_OS = normalizeAgentOs(external_node_os_namespaceObject.platform())
         const AGENT_ARCH = normalizeAgentArch(external_node_os_namespaceObject.arch())
 
+        // Internal test toggle: when true, we ask the control-plane to skip posting
+        // the profile GitHub App comment for this run.
+        const skipProfileGitHubComment = getEnv("GARNET_ACTION_SKIP_GITHUB_APP_COMMENT", "false") === "true"
+
         const controlPlaneClient = new ControlPlaneClient({
             baseURL: API,
             projectToken: TOKEN,
@@ -39576,7 +39582,8 @@ async function run() {
         let AGENT_ID = ""
         let AGENT_TOKEN = ""
         try {
-            const createdAgent = await controlPlaneClient.createAgent({
+            /** @type {import("./control-plane/types.js").CreateAgentRequest} */
+            const createAgentInput = {
                 os: AGENT_OS,
                 arch: AGENT_ARCH,
                 hostname: HOSTNAME,
@@ -39585,7 +39592,15 @@ async function run() {
                 machine_id: MACHINE_ID,
                 kind: "github",
                 github_context: githubContext,
-            })
+            }
+
+            if (skipProfileGitHubComment) {
+                createAgentInput.labels = {
+                    "garnet.ai/skipProfileGitHubComment": "true",
+                }
+            }
+
+            const createdAgent = await controlPlaneClient.createAgent(createAgentInput)
             AGENT_ID = createdAgent.id
             AGENT_TOKEN = createdAgent.agent_token
         } catch (error) {

--- a/src/action.js
+++ b/src/action.js
@@ -123,6 +123,10 @@ export async function run() {
         const AGENT_OS = normalizeAgentOs(os.platform())
         const AGENT_ARCH = normalizeAgentArch(os.arch())
 
+        // Internal test toggle: when true, we ask the control-plane to skip posting
+        // the profile GitHub App comment for this run.
+        const skipProfileGitHubComment = getEnv("GARNET_ACTION_SKIP_GITHUB_APP_COMMENT", "false") === "true"
+
         const controlPlaneClient = new ControlPlaneClient({
             baseURL: API,
             projectToken: TOKEN,
@@ -134,7 +138,8 @@ export async function run() {
         let AGENT_ID = ""
         let AGENT_TOKEN = ""
         try {
-            const createdAgent = await controlPlaneClient.createAgent({
+            /** @type {import("./control-plane/types.js").CreateAgentRequest} */
+            const createAgentInput = {
                 os: AGENT_OS,
                 arch: AGENT_ARCH,
                 hostname: HOSTNAME,
@@ -143,7 +148,15 @@ export async function run() {
                 machine_id: MACHINE_ID,
                 kind: "github",
                 github_context: githubContext,
-            })
+            }
+
+            if (skipProfileGitHubComment) {
+                createAgentInput.labels = {
+                    "garnet.ai/skipProfileGitHubComment": "true",
+                }
+            }
+
+            const createdAgent = await controlPlaneClient.createAgent(createAgentInput)
             AGENT_ID = createdAgent.id
             AGENT_TOKEN = createdAgent.agent_token
         } catch (error) {

--- a/src/control-plane/types.js
+++ b/src/control-plane/types.js
@@ -21,6 +21,7 @@ import { z } from "zod"
  *   machine_id: string
  *   kind: "github" | "kubernetes"
  *   github_context?: AgentGithubContext
+ *   labels?: Record<string, string>
  * }} CreateAgentRequest
  */
 
@@ -68,6 +69,7 @@ export const CREATE_AGENT_REQUEST_SCHEMA = z.object({
     machine_id: z.string().min(1),
     kind: z.enum(["github", "kubernetes"]),
     github_context: AGENT_GITHUB_CONTEXT_SCHEMA.optional(),
+    labels: z.record(z.string(), z.string()).optional(),
 })
 
 export const AGENT_CREATED_RESPONSE_SCHEMA = z.object({


### PR DESCRIPTION
Allow skipping GitHub App comment when `GARNET_ACTION_SKIP_GITHUB_APP_COMMENT` env variable is set to `true`.

This is so we can test the comment created by the action itself, instead of the one created by control-plane.