### PR TITLE
feat: restore tabular Garnet Runtime Report for the Step Summary

### DIFF
--- a/src/post.js
+++ b/src/post.js
@@ -5,8 +5,9 @@ import * as os from "node:os"
 import { getEnv, getErrorMessage, isSupportedArch, isSupportedPlatform, pathExists } from "./shared.js"
 import { getPullRequestNumberFromEvent } from "./github-event.js"
 import { uploadJibrilArtifacts } from "./post-artifacts.js"
-import { buildProfileRunReview, getDefaultJsonProfileFile, parseProfileJson } from "./profile-comment.js"
-import { renderNoRecord, renderStepSummary } from "./runtime-review.js"
+import { getDefaultJsonProfileFile, parseProfileJson } from "./profile-comment.js"
+import { renderNoRecord } from "./runtime-review.js"
+import { renderProfileStepSummary } from "./step-summary.js"
 import { publishPullRequestComment } from "./pr-comment.js"
 
 /** @typedef {import("./profile-comment.js").NormalizedProfile} NormalizedProfile */
@@ -112,8 +113,8 @@ function getRenderOptions() {
 }
 
 /**
- * Writes the full-detail Runtime Review snapshot to the GitHub Step Summary
- * (no elision, no folds, no markers).
+ * Writes the tabular Garnet Runtime Report to the GitHub Step Summary
+ * (workload, egress table, telemetry counts, assertions).
  * @param {NormalizedProfile | null} profile
  * @param {RenderOptions} renderOptions
  * @returns {Promise<void>}
@@ -137,8 +138,7 @@ async function appendRuntimeReviewSummary(profile, renderOptions) {
             renderedAt: renderOptions.renderedAt ?? new Date(),
         })
     } else {
-        const review = buildProfileRunReview([profile], renderOptions)
-        content = renderStepSummary(review)
+        content = renderProfileStepSummary(profile)
     }
 
     await fs.appendFile(summaryFile, `\n${content}\n`)

--- a/src/step-summary.js
+++ b/src/step-summary.js
@@ -1,0 +1,275 @@
+// Renders the per-job Garnet Runtime Report for the GitHub Step Summary.
+// This is the tabular report layout (workload, egress table, telemetry
+// counts, assertions) rendered from the normalized JSON profile. It is
+// observation-only: no verdict headline and no pass/fail status column.
+
+/** @typedef {import("./profile-comment.js").NormalizedProfile} NormalizedProfile */
+/** @typedef {import("./profile-comment.js").ProcTree} ProcTree */
+
+/**
+ * Render one job's Run Profile as the Step Summary report.
+ * @param {NormalizedProfile} profile
+ * @returns {string}
+ */
+export function renderProfileStepSummary(profile) {
+    const sections = [
+        "### Garnet Runtime Report",
+        "",
+        renderWorkloadSection(profile),
+        "",
+        renderNetworkSection(profile),
+        "",
+        renderAssertionSection(profile),
+        "",
+        renderFooter(profile),
+    ]
+
+    return sections.join("\n")
+}
+
+/**
+ * @param {NormalizedProfile} profile
+ * @returns {string}
+ */
+function renderWorkloadSection(profile) {
+    const github = profile.github
+    if (
+        github.workflow === "" &&
+        github.repository === "" &&
+        github.ref === "" &&
+        github.sha === "" &&
+        github.actor === "" &&
+        github.run_id === "" &&
+        github.job === ""
+    ) {
+        return ["#### Workload Summary", "", "No workload information available."].join("\n")
+    }
+
+    const table = renderKeyValueTable([
+        ["Workflow", github.workflow],
+        ["Repository", github.repository],
+        ["Branch", github.ref],
+        ["Commit", github.sha],
+        ["Triggered by", github.actor],
+        ["Run ID / Job", formatRunJob(github.run_id, github.job)],
+    ])
+
+    return ["#### Workload Summary", "", table].join("\n")
+}
+
+/**
+ * @param {NormalizedProfile} profile
+ * @returns {string}
+ */
+function renderNetworkSection(profile) {
+    if (!hasNetworkData(profile)) {
+        return [
+            "#### Network Egress Summary",
+            "",
+            "Duplicate egress destinations including their process tree are omitted.",
+            "",
+            "No network information available.",
+        ].join("\n")
+    }
+
+    /** @type {string[][]} */
+    const rows = []
+    /** @type {Set<string>} */
+    const seen = new Set()
+    let skippedRemoteNames = 0
+    let totalRemoteNames = 0
+
+    for (const peer of profile.egress_peers) {
+        for (const remoteName of peer.remote_names) {
+            totalRemoteNames += 1
+            if (seen.has(remoteName)) {
+                skippedRemoteNames += 1
+                continue
+            }
+            seen.add(remoteName)
+
+            rows.push([`\`${escapeMarkdown(remoteName)}\``, renderProcessTrees(peer.proc_trees)])
+        }
+    }
+
+    const egressTable =
+        rows.length > 0 ? renderTable(["Destination", "Process Tree"], rows) : "No egress peers information available."
+
+    /** @type {[string, string][]} */
+    const telemetryRows = [
+        ["Total egress unique domain(s)", String(profile.telemetry.total_domains)],
+        ["Total egress destination(s)", String(totalRemoteNames)],
+        ["Total egress omitted destination(s)", String(skippedRemoteNames)],
+        ["Total egress connection(s)", String(profile.telemetry.total_connections)],
+        ["Total egress flow(s)", String(profile.egress_peers.length)],
+    ]
+
+    return [
+        "#### Network Egress Summary",
+        "",
+        "Duplicate egress destinations including their process tree are omitted.",
+        "",
+        egressTable,
+        "",
+        "##### Network Telemetry Summary",
+        "",
+        renderKeyValueTable(telemetryRows),
+    ].join("\n")
+}
+
+/**
+ * @param {NormalizedProfile} profile
+ * @returns {string}
+ */
+function renderAssertionSection(profile) {
+    if (profile.assertions.length === 0) {
+        return ["#### Assertions", "", "No assertions information available."].join("\n")
+    }
+
+    const rows = profile.assertions.map(assertion => [
+        `\`${escapeMarkdown(assertion.id)}\``,
+        escapeMarkdown(assertion.result),
+    ])
+
+    return ["#### Assertions", "", renderTable(["Assertion", "Result"], rows)].join("\n")
+}
+
+/**
+ * @param {NormalizedProfile} profile
+ * @returns {string}
+ */
+function renderFooter(profile) {
+    /** @type {string[]} */
+    const footerParts = []
+    footerParts.push(
+        `${profile.telemetry.total_domains} unique domains · ${profile.telemetry.total_connections} connections`,
+    )
+    if (profile.github.run_id !== "" || profile.github.job !== "") {
+        footerParts.push(
+            `Workflow ${escapeHtml(getDisplayValue(profile.github.workflow, "-"))} - Run #${escapeHtml(getDisplayValue(profile.github.run_id, "-"))} - Job ${escapeHtml(getDisplayValue(profile.github.job, "-"))}`,
+        )
+    }
+    if (profile.timestamp !== "") {
+        footerParts.push(`timestamp ${escapeHtml(profile.timestamp)}`)
+    }
+
+    const header = footerParts.join("  -  ")
+    const viewLink =
+        profile.report_link !== "" ? ` · <a href="${escapeHtml(profile.report_link)}">View full report ↗</a>` : ""
+
+    return `<div align="right"><sub>${header}</sub><br><b>Powered by Garnet</b>${viewLink}</div>`
+}
+
+/**
+ * @param {NormalizedProfile} profile
+ * @returns {boolean}
+ */
+function hasNetworkData(profile) {
+    return (
+        profile.egress_peers.length > 0 ||
+        profile.telemetry.total_domains > 0 ||
+        profile.telemetry.total_connections > 0
+    )
+}
+
+/**
+ * @param {ProcTree[]} procTrees
+ * @returns {string}
+ */
+function renderProcessTrees(procTrees) {
+    const rendered = procTrees
+        .map(procTree => {
+            if (procTree.ancestry.length === 0) {
+                return ""
+            }
+
+            const [rootProcess, ...remainingAncestry] = procTree.ancestry
+            if (rootProcess === undefined || rootProcess === "") {
+                return ""
+            }
+
+            const items = []
+            items.push(`\`${escapeMarkdown(rootProcess)}\``)
+
+            let start = 1
+            if (procTree.ancestry.length > 4) {
+                start = procTree.ancestry.length - 3
+                items.push("`...`")
+            }
+
+            for (const processName of remainingAncestry.slice(start - 1)) {
+                items.push(`\`${escapeMarkdown(processName)}\``)
+            }
+
+            return items.join(" → ")
+        })
+        .filter(value => value.length > 0)
+
+    return rendered.length > 0 ? rendered.join("<br>") : "-"
+}
+
+/**
+ * @param {string} runId
+ * @param {string} job
+ * @returns {string}
+ */
+function formatRunJob(runId, job) {
+    /** @type {string[]} */
+    const parts = []
+    if (runId !== "") {
+        parts.push(runId)
+    }
+    if (job !== "") {
+        parts.push(job)
+    }
+
+    return parts.length > 0 ? parts.join(" / ") : "-"
+}
+
+/**
+ * @param {string[]} headers
+ * @param {string[][]} rows
+ * @returns {string}
+ */
+function renderTable(headers, rows) {
+    const headerRow = `| ${headers.map(header => escapeMarkdown(header)).join(" | ")} |`
+    const separatorRow = `| ${headers.map(() => "---").join(" | ")} |`
+    const bodyRows = rows.map(row => `| ${row.join(" | ")} |`)
+    return [headerRow, separatorRow, ...bodyRows].join("\n")
+}
+
+/**
+ * @param {[string, string][]} rows
+ * @returns {string}
+ */
+function renderKeyValueTable(rows) {
+    return renderTable(
+        ["Field", "Value"],
+        rows.map(([key, value]) => [escapeMarkdown(key), escapeMarkdown(getDisplayValue(value, "-"))]),
+    )
+}
+
+/**
+ * @param {string} value
+ * @param {string} fallback
+ * @returns {string}
+ */
+function getDisplayValue(value, fallback) {
+    return value !== "" ? value : fallback
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeMarkdown(value) {
+    return value.replaceAll("\\", "\\\\").replaceAll("|", "\\|").replaceAll("`", "\\`").replaceAll("\n", " ")
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeHtml(value) {
+    return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;")
+}

--- a/test/step-summary.test.js
+++ b/test/step-summary.test.js
@@ -1,0 +1,88 @@
+/**
+ * The Step Summary renders the tabular Garnet Runtime Report from a
+ * normalized profile: workload table, egress table, telemetry counts and
+ * assertions — observation-only (no verdict headline, no status column).
+ */
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import { fileURLToPath } from "node:url"
+import { dirname, join } from "node:path"
+import { parseProfileJson } from "../src/profile-comment.js"
+import { renderProfileStepSummary } from "../src/step-summary.js"
+
+const here = dirname(fileURLToPath(import.meta.url))
+const fixturesDir = join(here, "fixtures")
+
+async function loadProfile(name) {
+    const raw = JSON.parse(await readFile(join(fixturesDir, "profiles", name), "utf8"))
+    return parseProfileJson(JSON.stringify({ timestamp: "2026-07-03T14:02:00Z", ...raw }))
+}
+
+const profile = await loadProfile("sample-profile.json")
+const summary = renderProfileStepSummary(profile)
+
+test("step summary: renders all report sections", () => {
+    assert.ok(summary.startsWith("### Garnet Runtime Report"))
+    assert.ok(summary.includes("#### Workload Summary"))
+    assert.ok(summary.includes("#### Network Egress Summary"))
+    assert.ok(summary.includes("##### Network Telemetry Summary"))
+    assert.ok(summary.includes("#### Assertions"))
+    assert.ok(summary.includes("<b>Powered by Garnet</b>"))
+})
+
+test("step summary: workload table carries the GitHub scenario", () => {
+    assert.ok(summary.includes(`| Workflow | ${profile.github.workflow} |`))
+    assert.ok(summary.includes(`| Repository | ${profile.github.repository} |`))
+    assert.ok(summary.includes(`| Commit | ${profile.github.sha} |`))
+    assert.ok(summary.includes(`| Run ID / Job | ${profile.github.run_id} / ${profile.github.job} |`))
+})
+
+test("step summary: egress table lists destinations with process trees and no status column", () => {
+    assert.ok(summary.includes("| Destination | Process Tree |"))
+    const firstName = profile.egress_peers[0].remote_names[0]
+    assert.ok(summary.includes(`| \`${firstName}\` |`))
+    assert.ok(summary.includes("`systemd` → `python3.10`"))
+    assert.ok(!summary.includes("| Status |"))
+})
+
+test("step summary: telemetry counts stay raw-true", () => {
+    assert.ok(summary.includes(`| Total egress unique domain(s) | ${profile.telemetry.total_domains} |`))
+    assert.ok(summary.includes(`| Total egress connection(s) | ${profile.telemetry.total_connections} |`))
+    const totalNames = profile.egress_peers.reduce((n, peer) => n + peer.remote_names.length, 0)
+    assert.ok(summary.includes(`| Total egress destination(s) | ${totalNames} |`))
+    assert.ok(summary.includes(`| Total egress flow(s) | ${profile.egress_peers.length} |`))
+})
+
+test("step summary: assertions listed as plain results without verdict framing", () => {
+    assert.ok(summary.includes("| Assertion | Result |"))
+    for (const assertion of profile.assertions) {
+        assert.ok(summary.includes(`| \`${assertion.id}\` | ${assertion.result} |`))
+    }
+    assert.ok(!summary.includes("✅"))
+    assert.ok(!summary.includes("🔴"))
+    assert.ok(!summary.includes("assertion(s) passed"))
+    assert.ok(!summary.includes("assertion(s) failed"))
+})
+
+test("step summary: footer carries telemetry, run identity, timestamp and report link", () => {
+    assert.ok(
+        summary.includes(
+            `${profile.telemetry.total_domains} unique domains · ${profile.telemetry.total_connections} connections`,
+        ),
+    )
+    assert.ok(summary.includes(`timestamp ${profile.timestamp}`))
+    assert.ok(summary.includes("View full report ↗"))
+})
+
+test("step summary: no network data renders placeholders instead of tables", () => {
+    const quiet = {
+        ...profile,
+        assertions: [],
+        egress_peers: [],
+        telemetry: { total_domains: 0, total_connections: 0 },
+    }
+    const quietSummary = renderProfileStepSummary(quiet)
+    assert.ok(quietSummary.includes("No network information available."))
+    assert.ok(quietSummary.includes("No assertions information available."))
+})


### PR DESCRIPTION
## Summary
The v5.2 port made the Step Summary render the same prose/lineage-tree layout as the PR comment. This restores the pre-5.2 tabular report design for the Step Summary only — the PR comment keeps the v5.2 Runtime Review contract unchanged.

New `src/step-summary.js` re-renders the old Jibril profiler-markdown layout action-side from the already-parsed `NormalizedProfile`, adapted to observation-only (no verdict framing):

- `### Garnet Runtime Report` — the `✅/🔴 N assertion(s) passed/failed` headline is dropped
- `#### Workload Summary` key/value table (workflow, repository, branch, commit, actor, run/job)
- `#### Network Egress Summary` — `| Destination | Process Tree |` table (the ✅/🔴 `Status` column is dropped; duplicate remote names deduped and counted as omitted)
- `##### Network Telemetry Summary` — unique domains / destinations / omitted / connections / flows counts
- `#### Assertions` — `| Assertion | Result |` with plain-text results (`pass` / `attention` / `fail`), no icons
- old right-aligned footer: `{domains} unique domains · {connections} connections - Workflow/Run/Job - timestamp` + `Powered by Garnet · View full report ↗`

`post.js` wiring:
```diff
 appendRuntimeReviewSummary(profile, renderOptions)
-    content = renderStepSummary(buildProfileRunReview([profile], renderOptions))
+    content = renderProfileStepSummary(profile)
```
`renderNoRecord` still handles the missing-profile case. `renderStepSummary` remains exported from `runtime-review.js` (unchanged, still covered by its tests) but is no longer used by the post step.

Adds `test/step-summary.test.js` rendering the `sample-profile.json` fixture; `dist/post/index.js` rebuilt via `npm run build`.

Link to Devin session: https://app.devin.ai/sessions/99a76de9a85c4f2cbd207544694ed08f
Requested by: @jadoonf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/garnet-org/action/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->