### PR TITLE
docs: use absolute URL for the README logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <a href="https://garnet.ai">
-    <img src="brand/garnet-logo.png" alt="Garnet" width="260" />
+    <img src="https://raw.githubusercontent.com/garnet-org/action/main/brand/garnet-logo.png" alt="Garnet" width="260" />
   </a>
 
   <p><strong>Runtime Review for your PRs</strong></p>


### PR DESCRIPTION
## Summary

The README logo uses the relative path `brand/garnet-logo.png`, which renders on github.com but breaks on surfaces that don't rewrite relative paths (notably the GitHub Marketplace listing). Switch it to the absolute raw URL `https://raw.githubusercontent.com/garnet-org/action/main/brand/garnet-logo.png` (file is on main, repo is public, raw URL serves `200 image/png`).

Link to Devin session: https://app.devin.ai/sessions/2f7c124f07e8407f8d926f6624c3d228
Requested by: @jadoonf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/garnet-org/action/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->