### PR TITLE
docs: drop the @main channel from user-facing versioning guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ jobs:
         run: npm test
 ```
 
-> **Tip:** Major tags such as `@v2` track the latest `v2.x.x` release automatically. Use `@main` only if you want the latest unreleased code, or pin to a full commit SHA for maximum supply-chain safety:
+> **Tip:** Major tags such as `@v2` track the latest `v2.x.x` release automatically. For maximum supply-chain safety, pin to a full commit SHA (Dependabot keeps SHA pins up to date):
 >
 > ```yaml
 > - uses: garnet-org/action@<commit-sha>
@@ -111,8 +111,8 @@ Install the companion GitHub App for the full Runtime Review experience in your 
 ### Versioning
 
 - `garnet-org/action@v2` tracks the latest `v2.x.x` release.
-- `garnet-org/action@main` tracks the latest unreleased code on the default branch.
 - Exact tags such as `garnet-org/action@v2.3.0` remain available when you want a fully pinned released version.
+- Pinning to a full commit SHA is the recommended posture for supply-chain safety; Dependabot bumps SHA pins automatically.
 
 ## Action vs. GitHub App
 


### PR DESCRIPTION
## Summary

Re-opens #116 with a **GitHub-verified commit** (recommitted via the Contents API) so the branch passes main's required-signatures rule; content is byte-identical to #116's README change: the Quickstart tip and Versioning list stop offering `@main` as a user-facing channel and lead with SHA pinning (Dependabot keeps pins fresh).

#116 auto-closed during the signature rewrite; this PR replaces it. Stacked under the v6.6.1 README hotfix (see follow-up PR based on this branch).


Link to Devin session: https://app.devin.ai/sessions/8a7b3964742d46e095e18f7c92542094
Requested by: @jadoonf