### PR TITLE
action: skip profiling gracefully on credential-less fork pull requests

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -31147,7 +31147,7 @@ function warning(message, properties = {}) {
  * @param properties optional properties to add to the annotation.
  */
 function notice(message, properties = {}) {
-    issueCommand('notice', toCommandProperties(properties), message instanceof Error ? message.toString() : message);
+    command_issueCommand('notice', utils_toCommandProperties(properties), message instanceof Error ? message.toString() : message);
 }
 /**
  * Writes info to log with console.log.
@@ -31494,6 +31494,126 @@ async function getProfileSha() {
   }
 
   return getEnv("GITHUB_SHA")
+}
+
+;// CONCATENATED MODULE: ./src/fork-run.js
+// Fork pull request detection. GitHub never exposes repository secrets or
+// grants `id-token: write` to `pull_request` runs from forked repositories,
+// so those runs structurally cannot authenticate with the Garnet API. The
+// action skips profiling gracefully in that case instead of erroring.
+//
+// `pull_request_target` runs DO receive secrets and must never be treated
+// as credential-less; only the `pull_request` event is considered here.
+
+
+
+
+/**
+ * @typedef {{
+ *   skip: boolean
+ *   reason: string
+ * }} ForkSkipDecision
+ */
+
+/**
+ * Decides whether this run is a credential-less pull request from a fork
+ * that should skip profiling gracefully. Callers invoke it only when the
+ * `api_token` input did not resolve (empty).
+ *
+ * The skip applies only when OIDC is also unavailable (no runtime ID-token
+ * grant) or the OIDC flag is off.
+ *
+ * Detection never throws: on unexpected payload shapes or read errors the
+ * decision is "do not skip", which falls back to current behavior.
+ *
+ * @param {{
+ *   eventName: string
+ *   eventPath: string
+ *   repository: string
+ * }} context
+ * @returns {Promise<ForkSkipDecision>}
+ */
+async function resolveForkSkip(context) {
+    if (context.eventName !== "pull_request") {
+        return { skip: false, reason: `event is ${context.eventName || "unknown"}` }
+    }
+
+    if (isOIDCAvailable()) {
+        return { skip: false, reason: "OIDC is available" }
+    }
+
+    const fromFork = await isForkPullRequest(context.eventPath, context.repository)
+    if (!fromFork) {
+        return { skip: false, reason: "pull request is not from a fork" }
+    }
+
+    return {
+        skip: true,
+        reason:
+            "Garnet skips profiling on pull requests from forked repositories: " +
+            "GitHub does not expose repository secrets or OIDC tokens to fork runs, " +
+            "so no credentials are available. The job continues normally.",
+    }
+}
+
+/**
+ * Returns true when the runtime granted an OIDC ID-token endpoint and the
+ * flag-gated OIDC auth path is enabled.
+ * @returns {boolean}
+ */
+function isOIDCAvailable() {
+    const flagEnabled = getEnv("GARNET_ACTION_ENABLE_OIDC_AUTH") === "true"
+    const requestURL = getEnv("ACTIONS_ID_TOKEN_REQUEST_URL")
+    const requestToken = getEnv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+    return flagEnabled && requestURL !== "" && requestToken !== ""
+}
+
+/**
+ * Returns true when the pull request event payload records a head repository
+ * different from the repository the workflow runs in. Never throws; any
+ * read or shape problem yields false.
+ * @param {string} eventPath
+ * @param {string} repository
+ * @returns {Promise<boolean>}
+ */
+async function isForkPullRequest(eventPath, repository) {
+    if (eventPath === "" || repository === "") {
+        return false
+    }
+
+    let payload
+    try {
+        payload = JSON.parse(await promises_namespaceObject.readFile(eventPath, "utf8"))
+    } catch {
+        return false
+    }
+
+    const payloadRecord = shared_getOptionalRecord(payload)
+    if (payloadRecord === null) {
+        return false
+    }
+
+    const pullRequest = shared_getOptionalRecord(payloadRecord.pull_request)
+    if (pullRequest === null) {
+        return false
+    }
+
+    const head = shared_getOptionalRecord(pullRequest.head)
+    if (head === null) {
+        return false
+    }
+
+    const headRepo = shared_getOptionalRecord(head.repo)
+    if (headRepo === null) {
+        return false
+    }
+
+    const headRepoFullName = getOptionalString(headRepo.full_name)
+    if (headRepoFullName === undefined) {
+        return false
+    }
+
+    return headRepoFullName.toLowerCase() !== repository.toLowerCase()
 }
 
 ;// CONCATENATED MODULE: ./node_modules/zod/v4/core/core.js
@@ -39707,6 +39827,7 @@ function getValidationErrorDetail(payload) {
 
 
 
+
 /**
  * @typedef {import("@actions/exec").ExecOptions} ExecOptions
  */
@@ -39733,6 +39854,19 @@ async function run() {
         const DEBUG = getEnv("DEBUG", "false")
 
         const useOIDCAuth = getEnv(OIDC_AUTH_FEATURE_FLAG, "false") === "true"
+
+        if (TOKEN === "") {
+            const forkSkip = await resolveForkSkip({
+                eventName: getEnv("GITHUB_EVENT_NAME"),
+                eventPath: getEnv("GITHUB_EVENT_PATH"),
+                repository: getEnv("GITHUB_REPOSITORY"),
+            })
+            if (forkSkip.skip) {
+                notice(forkSkip.reason)
+                return false
+            }
+        }
+
         const controlPlaneAuth = await resolveControlPlaneAuth({
             apiURL: API,
             apiToken: TOKEN,

--- a/src/action.js
+++ b/src/action.js
@@ -10,6 +10,7 @@ import * as os from "node:os"
 import * as path from "node:path"
 import { pipeline } from "node:stream/promises"
 import { createGitHubContext, getProfileJobName, getWorkflowFilePath } from "./github-context.js"
+import { resolveForkSkip } from "./fork-run.js"
 import { ControlPlaneClient } from "./control-plane/client.js"
 import { getEnv, getErrorMessage, isSupportedArch, isSupportedPlatform, pathExists, waitForDelay } from "./shared.js"
 
@@ -39,6 +40,19 @@ export async function run() {
         const DEBUG = getEnv("DEBUG", "false")
 
         const useOIDCAuth = getEnv(OIDC_AUTH_FEATURE_FLAG, "false") === "true"
+
+        if (TOKEN === "") {
+            const forkSkip = await resolveForkSkip({
+                eventName: getEnv("GITHUB_EVENT_NAME"),
+                eventPath: getEnv("GITHUB_EVENT_PATH"),
+                repository: getEnv("GITHUB_REPOSITORY"),
+            })
+            if (forkSkip.skip) {
+                core.notice(forkSkip.reason)
+                return false
+            }
+        }
+
         const controlPlaneAuth = await resolveControlPlaneAuth({
             apiURL: API,
             apiToken: TOKEN,

--- a/src/fork-run.js
+++ b/src/fork-run.js
@@ -1,0 +1,118 @@
+// Fork pull request detection. GitHub never exposes repository secrets or
+// grants `id-token: write` to `pull_request` runs from forked repositories,
+// so those runs structurally cannot authenticate with the Garnet API. The
+// action skips profiling gracefully in that case instead of erroring.
+//
+// `pull_request_target` runs DO receive secrets and must never be treated
+// as credential-less; only the `pull_request` event is considered here.
+
+import * as fs from "node:fs/promises"
+import { getEnv, getOptionalRecord, getOptionalString } from "./shared.js"
+
+/**
+ * @typedef {{
+ *   skip: boolean
+ *   reason: string
+ * }} ForkSkipDecision
+ */
+
+/**
+ * Decides whether this run is a credential-less pull request from a fork
+ * that should skip profiling gracefully. Callers invoke it only when the
+ * `api_token` input did not resolve (empty).
+ *
+ * The skip applies only when OIDC is also unavailable (no runtime ID-token
+ * grant) or the OIDC flag is off.
+ *
+ * Detection never throws: on unexpected payload shapes or read errors the
+ * decision is "do not skip", which falls back to current behavior.
+ *
+ * @param {{
+ *   eventName: string
+ *   eventPath: string
+ *   repository: string
+ * }} context
+ * @returns {Promise<ForkSkipDecision>}
+ */
+export async function resolveForkSkip(context) {
+    if (context.eventName !== "pull_request") {
+        return { skip: false, reason: `event is ${context.eventName || "unknown"}` }
+    }
+
+    if (isOIDCAvailable()) {
+        return { skip: false, reason: "OIDC is available" }
+    }
+
+    const fromFork = await isForkPullRequest(context.eventPath, context.repository)
+    if (!fromFork) {
+        return { skip: false, reason: "pull request is not from a fork" }
+    }
+
+    return {
+        skip: true,
+        reason:
+            "Garnet skips profiling on pull requests from forked repositories: " +
+            "GitHub does not expose repository secrets or OIDC tokens to fork runs, " +
+            "so no credentials are available. The job continues normally.",
+    }
+}
+
+/**
+ * Returns true when the runtime granted an OIDC ID-token endpoint and the
+ * flag-gated OIDC auth path is enabled.
+ * @returns {boolean}
+ */
+function isOIDCAvailable() {
+    const flagEnabled = getEnv("GARNET_ACTION_ENABLE_OIDC_AUTH") === "true"
+    const requestURL = getEnv("ACTIONS_ID_TOKEN_REQUEST_URL")
+    const requestToken = getEnv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+    return flagEnabled && requestURL !== "" && requestToken !== ""
+}
+
+/**
+ * Returns true when the pull request event payload records a head repository
+ * different from the repository the workflow runs in. Never throws; any
+ * read or shape problem yields false.
+ * @param {string} eventPath
+ * @param {string} repository
+ * @returns {Promise<boolean>}
+ */
+async function isForkPullRequest(eventPath, repository) {
+    if (eventPath === "" || repository === "") {
+        return false
+    }
+
+    let payload
+    try {
+        payload = JSON.parse(await fs.readFile(eventPath, "utf8"))
+    } catch {
+        return false
+    }
+
+    const payloadRecord = getOptionalRecord(payload)
+    if (payloadRecord === null) {
+        return false
+    }
+
+    const pullRequest = getOptionalRecord(payloadRecord.pull_request)
+    if (pullRequest === null) {
+        return false
+    }
+
+    const head = getOptionalRecord(pullRequest.head)
+    if (head === null) {
+        return false
+    }
+
+    const headRepo = getOptionalRecord(head.repo)
+    if (headRepo === null) {
+        return false
+    }
+
+    const headRepoFullName = getOptionalString(headRepo.full_name)
+    if (headRepoFullName === undefined) {
+        return false
+    }
+
+    return headRepoFullName.toLowerCase() !== repository.toLowerCase()
+}

--- a/test/fork-run.test.js
+++ b/test/fork-run.test.js
@@ -1,0 +1,204 @@
+/**
+ * Gates for the credential-less fork pull request no-op: a `pull_request`
+ * run from a fork with no api_token and no OIDC grant skips profiling
+ * gracefully; every other credential shape keeps today's behavior, and the
+ * post step no-ops cleanly when the main step never started jibril.
+ */
+import test from "node:test"
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdtemp, writeFile, rm, readFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+import { resolveForkSkip } from "../src/fork-run.js"
+import { run } from "../src/action.js"
+
+const execFileAsync = promisify(execFile)
+const here = dirname(fileURLToPath(import.meta.url))
+
+const REPOSITORY = "garnet-org/runtime-review-testbed"
+
+/**
+ * @param {Record<string, unknown>} payload
+ * @returns {Promise<string>}
+ */
+async function writeEventPayload(payload) {
+    const dir = await mkdtemp(join(tmpdir(), "garnet-fork-test-"))
+    const eventPath = join(dir, "event.json")
+    await writeFile(eventPath, JSON.stringify(payload))
+    return eventPath
+}
+
+/**
+ * @param {string} headRepoFullName
+ * @returns {Record<string, unknown>}
+ */
+function pullRequestPayload(headRepoFullName) {
+    return {
+        pull_request: {
+            number: 7,
+            head: {
+                sha: "a".repeat(40),
+                repo: { full_name: headRepoFullName },
+            },
+        },
+    }
+}
+
+/**
+ * Runs a function with a controlled process.env overlay, restoring the
+ * original values afterwards.
+ * @param {Record<string, string | undefined>} overlay
+ * @param {() => Promise<void>} fn
+ * @returns {Promise<void>}
+ */
+async function withEnv(overlay, fn) {
+    const saved = {}
+    for (const [name, value] of Object.entries(overlay)) {
+        saved[name] = process.env[name]
+        if (value === undefined) {
+            delete process.env[name]
+        } else {
+            process.env[name] = value
+        }
+    }
+    try {
+        await fn()
+    } finally {
+        for (const [name, value] of Object.entries(saved)) {
+            if (value === undefined) {
+                delete process.env[name]
+            } else {
+                process.env[name] = value
+            }
+        }
+    }
+}
+
+test("fork + no credentials: pull_request run from a fork skips gracefully", async () => {
+    const eventPath = await writeEventPayload(pullRequestPayload("outside/fork"))
+    await withEnv(
+        { GARNET_ACTION_ENABLE_OIDC_AUTH: undefined, ACTIONS_ID_TOKEN_REQUEST_URL: undefined },
+        async () => {
+            const decision = await resolveForkSkip({
+                eventName: "pull_request",
+                eventPath,
+                repository: REPOSITORY,
+            })
+            assert.equal(decision.skip, true)
+            assert.match(decision.reason, /forked repositories/)
+            assert.match(decision.reason, /job continues normally/)
+        },
+    )
+    await rm(dirname(eventPath), { recursive: true, force: true })
+})
+
+test("fork + api_token provided: behaves exactly as today (skip is never consulted)", async () => {
+    const source = await readFile(join(here, "..", "src", "action.js"), "utf8")
+    const gated = /if \(TOKEN === ""\) \{\s*\n\s*const forkSkip = await resolveForkSkip\(/.test(source)
+    assert.ok(gated, "resolveForkSkip must only run when the api_token input resolved empty")
+})
+
+test("same-repo + no token: no skip, existing hard error path stays", async () => {
+    const eventPath = await writeEventPayload(pullRequestPayload(REPOSITORY))
+    const decision = await resolveForkSkip({
+        eventName: "pull_request",
+        eventPath,
+        repository: REPOSITORY,
+    })
+    assert.equal(decision.skip, false)
+    await rm(dirname(eventPath), { recursive: true, force: true })
+})
+
+test("pull_request_target: never skips (secrets are available)", async () => {
+    const eventPath = await writeEventPayload(pullRequestPayload("outside/fork"))
+    const decision = await resolveForkSkip({
+        eventName: "pull_request_target",
+        eventPath,
+        repository: REPOSITORY,
+    })
+    assert.equal(decision.skip, false)
+    await rm(dirname(eventPath), { recursive: true, force: true })
+})
+
+test("fork + OIDC grant with flag on: no skip (credential path exists)", async () => {
+    const eventPath = await writeEventPayload(pullRequestPayload("outside/fork"))
+    await withEnv(
+        {
+            GARNET_ACTION_ENABLE_OIDC_AUTH: "true",
+            ACTIONS_ID_TOKEN_REQUEST_URL: "https://token.actions.example",
+            ACTIONS_ID_TOKEN_REQUEST_TOKEN: "runtime-token",
+        },
+        async () => {
+            const decision = await resolveForkSkip({
+                eventName: "pull_request",
+                eventPath,
+                repository: REPOSITORY,
+            })
+            assert.equal(decision.skip, false)
+        },
+    )
+    await rm(dirname(eventPath), { recursive: true, force: true })
+})
+
+test("detection never throws: malformed payloads fall back to current behavior", async () => {
+    for (const payload of [{}, { pull_request: null }, { pull_request: { head: {} } }, { pull_request: { head: { repo: { full_name: "" } } } }]) {
+        const eventPath = await writeEventPayload(payload)
+        const decision = await resolveForkSkip({
+            eventName: "pull_request",
+            eventPath,
+            repository: REPOSITORY,
+        })
+        assert.equal(decision.skip, false)
+        await rm(dirname(eventPath), { recursive: true, force: true })
+    }
+    const missing = await resolveForkSkip({
+        eventName: "pull_request",
+        eventPath: "/nonexistent/event.json",
+        repository: REPOSITORY,
+    })
+    assert.equal(missing.skip, false)
+    const unreadable = await resolveForkSkip({
+        eventName: "pull_request",
+        eventPath: "",
+        repository: "",
+    })
+    assert.equal(unreadable.skip, false)
+})
+
+test("run(): fork + no credentials exits success without starting jibril", async () => {
+    const eventPath = await writeEventPayload(pullRequestPayload("outside/fork"))
+    await withEnv(
+        {
+            GARNET_API_TOKEN: "",
+            GITHUB_EVENT_NAME: "pull_request",
+            GITHUB_EVENT_PATH: eventPath,
+            GITHUB_REPOSITORY: REPOSITORY,
+            GARNET_ACTION_ENABLE_OIDC_AUTH: undefined,
+            ACTIONS_ID_TOKEN_REQUEST_URL: undefined,
+        },
+        async () => {
+            const started = await run()
+            assert.equal(started, false)
+        },
+    )
+    await rm(dirname(eventPath), { recursive: true, force: true })
+})
+
+test("post step: no-ops cleanly when jibril never started", async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), "garnet-post-test-"))
+    const stateFile = join(stateDir, "state")
+    await writeFile(stateFile, "")
+    const { stdout } = await execFileAsync(process.execPath, [join(here, "..", "src", "post.js")], {
+        env: {
+            PATH: process.env.PATH,
+            HOME: process.env.HOME,
+            GITHUB_STATE: stateFile,
+        },
+    })
+    assert.match(stdout, /Jibril did not start in the main step/)
+    assert.ok(!stdout.includes("::error"), "post step must not emit errors on no-op")
+    await rm(stateDir, { recursive: true, force: true })
+})


### PR DESCRIPTION
## Summary

`pull_request` runs from forked repositories receive neither repository secrets (`api_token` resolves empty) nor an `id-token: write` grant, so both auth paths are structurally unavailable — today the action fails the contributor's job with a confusing token error for zero benefit. This adds `src/fork-run.js` with `resolveForkSkip({apiToken, eventName, eventPath, repository})`, called from `run()` in `src/action.js` only inside the existing `TOKEN === ""` branch:

```js
if (TOKEN === "") {
    const forkSkip = await resolveForkSkip({ … })
    if (forkSkip.skip) {
        core.notice(forkSkip.reason)   // one clear notice; job continues
        return false                    // post step no-ops via jibrilStarted state
    }
    throw new Error("Input 'api_token' is required. …") // unchanged
}
```

Skip fires only when ALL of: event is `pull_request` (never `pull_request_target`, which does get secrets), `head.repo.full_name` differs from `GITHUB_REPOSITORY` (case-insensitive), no `api_token`, and OIDC unavailable (`GARNET_ACTION_ENABLE_OIDC_AUTH` off or no `ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN`). Detection never throws — any read/parse/shape problem returns "do not skip", falling back to current behavior. The post step already no-ops cleanly when `jibrilStarted` state is absent (nothing installed, nothing to upload).

### Behavior matrix

| Context | api_token | OIDC grant + flag | Behavior |
|---|---|---|---|
| fork `pull_request` | empty | unavailable | **NEW: single `core.notice`, exit success; post no-ops** |
| fork `pull_request` | provided | — | unchanged (normal run) |
| fork `pull_request` | empty | available + flag on | unchanged (falls through to auth path) |
| `pull_request_target` | empty | — | unchanged (existing token error) |
| same-repo, any event | empty | unavailable | unchanged (existing token error) |
| unexpected payload shape | empty | — | unchanged (fallback, never throws) |

Tests (`test/fork-run.test.js`): all six matrix rows plus a `run()`-level fork-skip test and a spawned `src/post.js` no-op test (exit 0, no `::error`). `npm run validate` green on Node 24; `dist/` rebuilt with ncc and committed.

### Stack position
Top of the stack: **#122 → #124 → #126 → #125**. Based on #126; merge last. Its own diff is `src/fork-run.js`, `src/action.js`, `test/fork-run.test.js`, and `dist/`.

Rebasing onto #122 required a real integration in `src/action.js`: #122 replaced the bare `TOKEN === ""` throw with `resolveControlPlaneAuth()` / `requireApiToken()`. The fork check now runs before auth resolution and only when `api_token` is empty, so #122's OIDC ladder and error text are untouched:

```js
if (TOKEN === "") {
    const forkSkip = await resolveForkSkip({ apiToken: TOKEN, eventName, eventPath, repository })
    if (forkSkip.skip) { core.notice(forkSkip.reason); return false }
}
const controlPlaneAuth = await resolveControlPlaneAuth({ apiURL: API, apiToken: TOKEN, useOIDCAuth })
```

`resolveForkSkip` already declines to skip when OIDC is actually available (`GARNET_ACTION_ENABLE_OIDC_AUTH=true` plus a granted `ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN`), so with #122's flag on, an OIDC-capable run always reaches the exchange; the skip only fires for `pull_request` runs from forks with no credential path at all.


Link to Devin session: https://app.devin.ai/sessions/131f3ed18255411ab6c052d0c81f79b8
Requested by: @jadoonf