### PR TITLE
ci: cron to update jibril version

### DIFF
--- a/.github/workflows/update-jibril-version.yaml
+++ b/.github/workflows/update-jibril-version.yaml
@@ -1,0 +1,130 @@
+# CI: dayly cron that fetches the latest stable Jibril release and opens a PR to bump
+# the pinned version in src/action.js, action.yaml, and README.md (plus a dist rebuild).
+#
+# No extra secrets required — garnet-org/jibril-releases is a public repo.
+
+name: Update Jibril default version
+
+on:
+  schedule:
+    - cron: "0 9 * * *"   # Daily at 09:00 UTC
+  workflow_dispatch:
+
+jobs:
+  update:
+    name: Update Jibril default version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Fetch latest stable Jibril release
+        id: jibril
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION=$(gh api "repos/garnet-org/jibril-releases/releases?per_page=50" \
+            --jq '[.[] | select(.prerelease == false and .draft == false) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | first | .tag_name')
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "::error::No stable semver Jibril release found"
+            exit 1
+          fi
+          echo "Latest stable Jibril release: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if update is needed
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.jibril.outputs.version }}
+        run: |
+          set -euo pipefail
+          BRANCH="update-jibril-version/$VERSION"
+          CURRENT=$(sed -n 's/^const JIBRIL_STABLE_VERSION = "\(.*\)"$/\1/p' src/action.js)
+
+          if [ "$CURRENT" = "$VERSION" ]; then
+            echo "Already at $VERSION — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null | grep -q '^[0-9]'; then
+            echo "PR already open for $BRANCH — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Will bump: $CURRENT → $VERSION"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Update src/action.js
+        if: steps.check.outputs.skip == 'false'
+        env:
+          VERSION: ${{ steps.jibril.outputs.version }}
+        run: |
+          set -euo pipefail
+          sed -i 's/const JIBRIL_STABLE_VERSION = "[^"]*"/const JIBRIL_STABLE_VERSION = "'"$VERSION"'"/' src/action.js
+
+      - name: Update action.yaml
+        if: steps.check.outputs.skip == 'false'
+        env:
+          VERSION: ${{ steps.jibril.outputs.version }}
+        run: |
+          set -euo pipefail
+          sed -i '/jibril_version:/,/default:/{s/default: "[^"]*"/default: "'"$VERSION"'"/}' action.yaml
+
+      - name: Update README.md
+        if: steps.check.outputs.skip == 'false'
+        env:
+          VERSION: ${{ steps.jibril.outputs.version }}
+        run: |
+          set -euo pipefail
+          sed -i -E 's/(`jibril_version`[^|]*\|[^|]*\| )`[^`]*`[^|]*/\1`'"$VERSION"'`             /' README.md
+
+      - name: Setup Node
+        if: steps.check.outputs.skip == 'false'
+        uses: actions/setup-node@v7
+        with:
+          node-version: "lts/*"
+
+      - name: Rebuild dist/
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          npm ci --include=dev
+          npm run build
+
+      - name: Open pull request
+        if: steps.check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.jibril.outputs.version }}
+        run: |
+          set -euo pipefail
+          BRANCH="update-jibril-version/$VERSION"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add src/action.js action.yaml README.md dist/
+          git commit -m "chore: update Jibril default version to $VERSION"
+          git push origin "$BRANCH"
+
+          cat > /tmp/pr-body.md << EOF
+          Bumps the pinned Jibril version to the latest stable release: \`$VERSION\`.
+
+          **Changed files:**
+          - \`src/action.js\` — \`JIBRIL_STABLE_VERSION\` constant
+          - \`action.yaml\` — \`jibril_version\` input default
+          - \`README.md\` — configuration table default column
+          - \`dist/\` — rebuilt bundles
+          EOF
+
+          gh pr create \
+            --title "chore: update Jibril default version to $VERSION" \
+            --body-file /tmp/pr-body.md \
+            --base main \
+            --head "$BRANCH"


### PR DESCRIPTION
Adding a cron job (daily) in CI to bump the jibril pinned version in `src/action.js`, `action.yaml`, and `README.md`.