### PR TITLE
security: validate untrusted inputs and harden comment trust and Markdown link sinks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Dogfooding
       - name: Run Garnet
@@ -32,7 +32,7 @@ jobs:
           jibril_version: "v0.0"
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7      
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1      
       - uses: garnet-org/action@ccd6b73fddaa3c64195b654090fc1bfcb07788fd
         with:
           api_token: ${{ secrets.GARNET_API_TOKEN }}

--- a/.github/workflows/pr-comment-smoke-test-a-and-b.yaml
+++ b/.github/workflows/pr-comment-smoke-test-a-and-b.yaml
@@ -41,7 +41,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Enable internal skip-comment mode
               if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skip-github-app-comment')
@@ -101,7 +101,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Enable internal skip-comment mode
               if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skip-github-app-comment')

--- a/.github/workflows/pr-comment-smoke-test-c.yaml
+++ b/.github/workflows/pr-comment-smoke-test-c.yaml
@@ -41,7 +41,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout
-              uses: actions/checkout@v7
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
             - name: Enable internal skip-comment mode
               if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skip-github-app-comment')

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Dogfooding
       - name: Run Garnet

--- a/.github/workflows/update-jibril-version.yaml
+++ b/.github/workflows/update-jibril-version.yaml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Fetch latest stable Jibril release
         id: jibril
@@ -87,7 +87,7 @@ jobs:
 
       - name: Setup Node
         if: steps.check.outputs.skip == 'false'
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
 

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -41544,7 +41544,7 @@ async function run() {
     try {
         // Get the variables from the environment.
         const TOKEN = getEnv("GARNET_API_TOKEN")
-        const API = getEnv("GARNET_API_URL", "https://api.garnet.ai")
+        const API = validateApiURL(getEnv("GARNET_API_URL", "https://api.garnet.ai"))
         let JIBRILVER = resolveJibrilVersion(getEnv("JIBRIL_VERSION", ""), getEnv("GITHUB_ACTION_REF", ""))
         const DEBUG = getEnv("DEBUG", "false")
 
@@ -41608,6 +41608,7 @@ async function run() {
         if (JIBRILVER !== "latest" && !JIBRILVER.startsWith("v")) {
             JIBRILVER = `v${JIBRILVER}`
         }
+        validateJibrilVersion(JIBRILVER)
 
         // The bundled tarball's filename embeds the tag, and the agent record
         // should name the exact sensor that ran.
@@ -41722,6 +41723,7 @@ async function run() {
                 workflow_name: WORKFLOW,
             })
 
+            validateNetworkPolicyYAML(networkPolicyYaml)
             await promises_namespaceObject.writeFile(NETPOLICY_PATH, networkPolicyYaml)
         } catch (error) {
             throw new Error(`Failed to fetch network policy: ${getErrorMessage(error)}`)
@@ -42075,6 +42077,80 @@ function requireApiToken(token) {
     throw new Error(
         "Input 'api_token' is required when OIDC authentication is unavailable. This commonly happens on pull requests from forks, where repository secrets are not exposed to workflows, or when 'id-token: write' permission is not granted. Add/verify that your workflow passes a valid token to this input, grant 'id-token: write', or conditionally skip this action for forked PRs.",
     )
+}
+
+// Accepted jibril_version shapes: `latest` or a release tag such as v0.0,
+// v2.16.0, 2.16.0, or v2.17.0-rc.1. Anything else is rejected before the
+// value reaches the release download URL.
+const JIBRIL_VERSION_PATTERN = /^v?\d+\.\d+(\.\d+)?(-[A-Za-z0-9.]+)?$/
+
+/**
+ * Rejects jibril_version values that do not name a release: the version is
+ * interpolated into the release download URL, so a free-form value could
+ * point the root-executed binary at an arbitrary URL path.
+ * @param {string} version
+ * @returns {string}
+ */
+function validateJibrilVersion(version) {
+    if (version === "latest" || JIBRIL_VERSION_PATTERN.test(version)) {
+        return version
+    }
+
+    throw new Error(
+        `Invalid jibril_version '${version}': expected 'latest' or a release version such as 'v2.16.0'.`,
+    )
+}
+
+/**
+ * Requires the API URL to be https (http is allowed for localhost only), so
+ * tokens are never sent in cleartext to a remote host.
+ * @param {string} value
+ * @returns {string}
+ */
+function validateApiURL(value) {
+    let parsed
+    try {
+        parsed = new URL(value)
+    } catch (_) {
+        throw new Error(`Invalid api_url '${value}': not a valid URL.`)
+    }
+
+    if (parsed.protocol === "https:") {
+        return value
+    }
+
+    const isLoopbackHost =
+        parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1" || parsed.hostname === "::1"
+    if (parsed.protocol === "http:" && isLoopbackHost) {
+        return value
+    }
+
+    throw new Error(`Invalid api_url '${value}': must use https (http is allowed for localhost only).`)
+}
+
+const NETPOLICY_MAX_BYTES = 1024 * 1024
+
+/**
+ * Sanity-checks the network policy fetched from the control plane before it
+ * is written under /etc/jibril: it must be non-empty printable YAML text of
+ * bounded size.
+ * @param {string} content
+ * @returns {string}
+ */
+function validateNetworkPolicyYAML(content) {
+    if (typeof content !== "string" || content.trim() === "") {
+        throw new Error("Network policy from the control plane is empty.")
+    }
+
+    if (Buffer.byteLength(content, "utf8") > NETPOLICY_MAX_BYTES) {
+        throw new Error("Network policy from the control plane exceeds the 1 MiB size bound.")
+    }
+
+    if (/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/.test(content)) {
+        throw new Error("Network policy from the control plane contains control characters.")
+    }
+
+    return content
 }
 
 /**
@@ -43795,10 +43871,83 @@ function edgeComparator(a, b) {
  */
 function runtime_review_pullRequestURL(github) {
   const match = /^refs\/pull\/(\d+)\//.exec(String(github.ref || ""))
-  const repository = String(github.repository || "")
+  const repository = safeRepositorySlug(github.repository)
   if (match === null || repository === "") return ""
-  const server = String(github.server_url || "https://github.com").replace(/\/+$/, "")
+  const server = safeServerURL(github.server_url)
+  if (server === "") return ""
   return `${server}/${repository}/pull/${match[1]}`
+}
+
+// Record-derived values that land in Markdown/HTML link targets are
+// untrusted input: a forged profile could carry markup-breaking or
+// javascript: values. These normalizers fail closed to "" (the renderers
+// already degrade to unlinked text on empty URLs).
+
+/**
+ * A GitHub `owner/name` slug restricted to the characters GitHub allows;
+ * anything else returns "".
+ * @param {unknown} value
+ * @returns {string}
+ */
+function safeRepositorySlug(value) {
+  const repository = String(value || "")
+  return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository) ? repository : ""
+}
+
+/**
+ * A server base URL that parses as http(s) with no path, query, fragment,
+ * or credentials; anything else falls back to "".
+ * @param {unknown} value
+ * @returns {string}
+ */
+function safeServerURL(value) {
+  const raw = String(value || "https://github.com").replace(/\/+$/, "")
+  let parsed
+  try {
+    parsed = new URL(raw)
+  } catch (_) {
+    return ""
+  }
+  const isHTTP = parsed.protocol === "https:" || parsed.protocol === "http:"
+  const isBare =
+    parsed.pathname === "/" &&
+    parsed.search === "" &&
+    parsed.hash === "" &&
+    parsed.username === "" &&
+    parsed.password === ""
+  return isHTTP && isBare ? raw : ""
+}
+
+/**
+ * The run URL derived from validated record fields; "" when any part is
+ * untrusted or missing.
+ * @param {Record<string, any>} github
+ * @returns {string}
+ */
+function buildRunURL(github) {
+  const repository = safeRepositorySlug(github.repository)
+  const server = safeServerURL(github.server_url)
+  const runID = String(github.run_id || "")
+  if (repository === "" || server === "" || !/^\d+$/.test(runID)) return ""
+  return `${server}/${repository}/actions/runs/${runID}`
+}
+
+/**
+ * An absolute http(s) URL for use as a link target; anything else
+ * (including javascript: and data: schemes) returns "".
+ * @param {unknown} value
+ * @returns {string}
+ */
+function safeHTTPURL(value) {
+  const raw = String(value || "")
+  if (raw === "") return ""
+  let parsed
+  try {
+    parsed = new URL(raw)
+  } catch (_) {
+    return ""
+  }
+  return parsed.protocol === "https:" || parsed.protocol === "http:" ? raw : ""
 }
 
 /**
@@ -43846,13 +43995,10 @@ function runtime_review_summarizeProfile(profile) {
   return {
     name: String(github.job || ""),
     workflow: String(github.workflow || ""),
-    repository: String(github.repository || ""),
+    repository: safeRepositorySlug(github.repository),
     sha: String(github.sha || ""),
     run_id: String(github.run_id || ""),
-    run_url:
-      github.run_id && github.repository
-        ? `${github.server_url || "https://github.com"}/${github.repository}/actions/runs/${github.run_id}`
-        : "",
+    run_url: buildRunURL(github),
     profile_id: String(envelope.id || envelope.profile_id || ""),
     uuid: String(p?.uuid || ""),
     timestamp: String(p?.timestamp || ""),
@@ -43976,8 +44122,8 @@ function runtime_review_buildRunReview(input) {
       name: String(j.name || ""),
       workflow: String(j.workflow || ""),
       run_id: String(j.run_id || ""),
-      run_url: String(j.run_url || ""),
-      job_url: String(j.job_url || ""),
+      run_url: safeHTTPURL(j.run_url),
+      job_url: safeHTTPURL(j.job_url),
       profile_id: String(j.profile_id || ""),
       uuid: String(j.uuid || ""),
       timestamp: String(j.timestamp || ""),
@@ -45426,7 +45572,8 @@ function retentionOrder(edges) {
  */
 function commitRef(sha, commitUrl) {
   const sha7 = escapeCode(sha.slice(0, 7) || "unknown")
-  return commitUrl ? `[\`${sha7}\`](${commitUrl})` : `\`${sha7}\``
+  const url = safeHTTPURL(commitUrl)
+  return url !== "" ? `[\`${sha7}\`](${url})` : `\`${sha7}\``
 }
 
 /**

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -150039,10 +150039,83 @@ function edgeComparator(a, b) {
  */
 function pullRequestURL(github) {
   const match = /^refs\/pull\/(\d+)\//.exec(String(github.ref || ""))
-  const repository = String(github.repository || "")
+  const repository = safeRepositorySlug(github.repository)
   if (match === null || repository === "") return ""
-  const server = String(github.server_url || "https://github.com").replace(/\/+$/, "")
+  const server = safeServerURL(github.server_url)
+  if (server === "") return ""
   return `${server}/${repository}/pull/${match[1]}`
+}
+
+// Record-derived values that land in Markdown/HTML link targets are
+// untrusted input: a forged profile could carry markup-breaking or
+// javascript: values. These normalizers fail closed to "" (the renderers
+// already degrade to unlinked text on empty URLs).
+
+/**
+ * A GitHub `owner/name` slug restricted to the characters GitHub allows;
+ * anything else returns "".
+ * @param {unknown} value
+ * @returns {string}
+ */
+function safeRepositorySlug(value) {
+  const repository = String(value || "")
+  return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository) ? repository : ""
+}
+
+/**
+ * A server base URL that parses as http(s) with no path, query, fragment,
+ * or credentials; anything else falls back to "".
+ * @param {unknown} value
+ * @returns {string}
+ */
+function safeServerURL(value) {
+  const raw = String(value || "https://github.com").replace(/\/+$/, "")
+  let parsed
+  try {
+    parsed = new URL(raw)
+  } catch (_) {
+    return ""
+  }
+  const isHTTP = parsed.protocol === "https:" || parsed.protocol === "http:"
+  const isBare =
+    parsed.pathname === "/" &&
+    parsed.search === "" &&
+    parsed.hash === "" &&
+    parsed.username === "" &&
+    parsed.password === ""
+  return isHTTP && isBare ? raw : ""
+}
+
+/**
+ * The run URL derived from validated record fields; "" when any part is
+ * untrusted or missing.
+ * @param {Record<string, any>} github
+ * @returns {string}
+ */
+function buildRunURL(github) {
+  const repository = safeRepositorySlug(github.repository)
+  const server = safeServerURL(github.server_url)
+  const runID = String(github.run_id || "")
+  if (repository === "" || server === "" || !/^\d+$/.test(runID)) return ""
+  return `${server}/${repository}/actions/runs/${runID}`
+}
+
+/**
+ * An absolute http(s) URL for use as a link target; anything else
+ * (including javascript: and data: schemes) returns "".
+ * @param {unknown} value
+ * @returns {string}
+ */
+function safeHTTPURL(value) {
+  const raw = String(value || "")
+  if (raw === "") return ""
+  let parsed
+  try {
+    parsed = new URL(raw)
+  } catch (_) {
+    return ""
+  }
+  return parsed.protocol === "https:" || parsed.protocol === "http:" ? raw : ""
 }
 
 /**
@@ -150090,13 +150163,10 @@ function summarizeProfile(profile) {
   return {
     name: String(github.job || ""),
     workflow: String(github.workflow || ""),
-    repository: String(github.repository || ""),
+    repository: safeRepositorySlug(github.repository),
     sha: String(github.sha || ""),
     run_id: String(github.run_id || ""),
-    run_url:
-      github.run_id && github.repository
-        ? `${github.server_url || "https://github.com"}/${github.repository}/actions/runs/${github.run_id}`
-        : "",
+    run_url: buildRunURL(github),
     profile_id: String(envelope.id || envelope.profile_id || ""),
     uuid: String(p?.uuid || ""),
     timestamp: String(p?.timestamp || ""),
@@ -150220,8 +150290,8 @@ function buildRunReview(input) {
       name: String(j.name || ""),
       workflow: String(j.workflow || ""),
       run_id: String(j.run_id || ""),
-      run_url: String(j.run_url || ""),
-      job_url: String(j.job_url || ""),
+      run_url: safeHTTPURL(j.run_url),
+      job_url: safeHTTPURL(j.job_url),
       profile_id: String(j.profile_id || ""),
       uuid: String(j.uuid || ""),
       timestamp: String(j.timestamp || ""),
@@ -151670,7 +151740,8 @@ function retentionOrder(edges) {
  */
 function commitRef(sha, commitUrl) {
   const sha7 = escapeCode(sha.slice(0, 7) || "unknown")
-  return commitUrl ? `[\`${sha7}\`](${commitUrl})` : `\`${sha7}\``
+  const url = safeHTTPURL(commitUrl)
+  return url !== "" ? `[\`${sha7}\`](${url})` : `\`${sha7}\``
 }
 
 /**
@@ -153685,7 +153756,7 @@ function getString(value) {
 
 
 /**
- * @typedef {{ id: number, body: string }} PullRequestComment
+ * @typedef {{ id: number, body: string, authorLogin?: string, authorType?: string }} PullRequestComment
  */
 
 class GitHubIssueCommentClient {
@@ -153793,9 +153864,21 @@ function normalizeComment(value) {
     return null
   }
 
-  return typeof value.id === "number" && typeof value.body === "string"
-    ? { id: value.id, body: value.body }
-    : null
+  if (typeof value.id !== "number" || typeof value.body !== "string") {
+    return null
+  }
+
+  /** @type {PullRequestComment} */
+  const comment = { id: value.id, body: value.body }
+  if (isRecord(value.user)) {
+    if (typeof value.user.login === "string") {
+      comment.authorLogin = value.user.login
+    }
+    if (typeof value.user.type === "string") {
+      comment.authorType = value.user.type
+    }
+  }
+  return comment
 }
 
 /**
@@ -153816,8 +153899,25 @@ function isPresent(value) {
  */
 
 /**
- * @typedef {{ id: number, body: string }} PullRequestComment
+ * @typedef {{ id: number, body: string, authorLogin?: string, authorType?: string }} PullRequestComment
  */
+
+// Marker text and hidden comment state only count when the comment was
+// authored by a bot (the workflow token's github-actions[bot] or the Garnet
+// App). A human commenter pasting the marker must not be able to suppress,
+// stale-mark, or hijack the Runtime Review comment. Comments without author
+// metadata (older normalized fixtures) stay trusted for compatibility.
+/**
+ * @param {PullRequestComment} comment
+ * @returns {boolean}
+ */
+function isTrustedCommentAuthor(comment) {
+    if (comment.authorType === undefined && comment.authorLogin === undefined) {
+        return true
+    }
+
+    return comment.authorType === "Bot"
+}
 
 /**
  * @typedef {{
@@ -153848,6 +153948,7 @@ function isPresent(value) {
  * @returns {PublishCommentPlan}
  */
 function planPullRequestComment(comments, profile, runAttempt, renderOptions = {}) {
+    comments = comments.filter(isTrustedCommentAuthor)
     if (containsControlPlaneComment(comments)) {
         return {
             kind: "blocked-by-control-plane",

--- a/src/action.js
+++ b/src/action.js
@@ -61,7 +61,7 @@ export async function run() {
     try {
         // Get the variables from the environment.
         const TOKEN = getEnv("GARNET_API_TOKEN")
-        const API = getEnv("GARNET_API_URL", "https://api.garnet.ai")
+        const API = validateApiURL(getEnv("GARNET_API_URL", "https://api.garnet.ai"))
         let JIBRILVER = resolveJibrilVersion(getEnv("JIBRIL_VERSION", ""), getEnv("GITHUB_ACTION_REF", ""))
         const DEBUG = getEnv("DEBUG", "false")
 
@@ -125,6 +125,7 @@ export async function run() {
         if (JIBRILVER !== "latest" && !JIBRILVER.startsWith("v")) {
             JIBRILVER = `v${JIBRILVER}`
         }
+        validateJibrilVersion(JIBRILVER)
 
         // The bundled tarball's filename embeds the tag, and the agent record
         // should name the exact sensor that ran.
@@ -239,6 +240,7 @@ export async function run() {
                 workflow_name: WORKFLOW,
             })
 
+            validateNetworkPolicyYAML(networkPolicyYaml)
             await fs.writeFile(NETPOLICY_PATH, networkPolicyYaml)
         } catch (error) {
             throw new Error(`Failed to fetch network policy: ${getErrorMessage(error)}`)
@@ -592,6 +594,80 @@ function requireApiToken(token) {
     throw new Error(
         "Input 'api_token' is required when OIDC authentication is unavailable. This commonly happens on pull requests from forks, where repository secrets are not exposed to workflows, or when 'id-token: write' permission is not granted. Add/verify that your workflow passes a valid token to this input, grant 'id-token: write', or conditionally skip this action for forked PRs.",
     )
+}
+
+// Accepted jibril_version shapes: `latest` or a release tag such as v0.0,
+// v2.16.0, 2.16.0, or v2.17.0-rc.1. Anything else is rejected before the
+// value reaches the release download URL.
+const JIBRIL_VERSION_PATTERN = /^v?\d+\.\d+(\.\d+)?(-[A-Za-z0-9.]+)?$/
+
+/**
+ * Rejects jibril_version values that do not name a release: the version is
+ * interpolated into the release download URL, so a free-form value could
+ * point the root-executed binary at an arbitrary URL path.
+ * @param {string} version
+ * @returns {string}
+ */
+export function validateJibrilVersion(version) {
+    if (version === "latest" || JIBRIL_VERSION_PATTERN.test(version)) {
+        return version
+    }
+
+    throw new Error(
+        `Invalid jibril_version '${version}': expected 'latest' or a release version such as 'v2.16.0'.`,
+    )
+}
+
+/**
+ * Requires the API URL to be https (http is allowed for localhost only), so
+ * tokens are never sent in cleartext to a remote host.
+ * @param {string} value
+ * @returns {string}
+ */
+export function validateApiURL(value) {
+    let parsed
+    try {
+        parsed = new URL(value)
+    } catch (_) {
+        throw new Error(`Invalid api_url '${value}': not a valid URL.`)
+    }
+
+    if (parsed.protocol === "https:") {
+        return value
+    }
+
+    const isLoopbackHost =
+        parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1" || parsed.hostname === "::1"
+    if (parsed.protocol === "http:" && isLoopbackHost) {
+        return value
+    }
+
+    throw new Error(`Invalid api_url '${value}': must use https (http is allowed for localhost only).`)
+}
+
+const NETPOLICY_MAX_BYTES = 1024 * 1024
+
+/**
+ * Sanity-checks the network policy fetched from the control plane before it
+ * is written under /etc/jibril: it must be non-empty printable YAML text of
+ * bounded size.
+ * @param {string} content
+ * @returns {string}
+ */
+export function validateNetworkPolicyYAML(content) {
+    if (typeof content !== "string" || content.trim() === "") {
+        throw new Error("Network policy from the control plane is empty.")
+    }
+
+    if (Buffer.byteLength(content, "utf8") > NETPOLICY_MAX_BYTES) {
+        throw new Error("Network policy from the control plane exceeds the 1 MiB size bound.")
+    }
+
+    if (/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/.test(content)) {
+        throw new Error("Network policy from the control plane contains control characters.")
+    }
+
+    return content
 }
 
 /**

--- a/src/github-issue-comment-client.js
+++ b/src/github-issue-comment-client.js
@@ -2,7 +2,7 @@ import * as github from "@actions/github"
 import { isRecord } from "./shared.js"
 
 /**
- * @typedef {{ id: number, body: string }} PullRequestComment
+ * @typedef {{ id: number, body: string, authorLogin?: string, authorType?: string }} PullRequestComment
  */
 
 export class GitHubIssueCommentClient {
@@ -110,9 +110,21 @@ function normalizeComment(value) {
     return null
   }
 
-  return typeof value.id === "number" && typeof value.body === "string"
-    ? { id: value.id, body: value.body }
-    : null
+  if (typeof value.id !== "number" || typeof value.body !== "string") {
+    return null
+  }
+
+  /** @type {PullRequestComment} */
+  const comment = { id: value.id, body: value.body }
+  if (isRecord(value.user)) {
+    if (typeof value.user.login === "string") {
+      comment.authorLogin = value.user.login
+    }
+    if (typeof value.user.type === "string") {
+      comment.authorType = value.user.type
+    }
+  }
+  return comment
 }
 
 /**

--- a/src/pr-comment-plan.js
+++ b/src/pr-comment-plan.js
@@ -6,8 +6,25 @@ import { CONTROL_PLANE_MARKERS, RUNTIME_REVIEW_MARKER } from "./runtime-review.j
  */
 
 /**
- * @typedef {{ id: number, body: string }} PullRequestComment
+ * @typedef {{ id: number, body: string, authorLogin?: string, authorType?: string }} PullRequestComment
  */
+
+// Marker text and hidden comment state only count when the comment was
+// authored by a bot (the workflow token's github-actions[bot] or the Garnet
+// App). A human commenter pasting the marker must not be able to suppress,
+// stale-mark, or hijack the Runtime Review comment. Comments without author
+// metadata (older normalized fixtures) stay trusted for compatibility.
+/**
+ * @param {PullRequestComment} comment
+ * @returns {boolean}
+ */
+function isTrustedCommentAuthor(comment) {
+    if (comment.authorType === undefined && comment.authorLogin === undefined) {
+        return true
+    }
+
+    return comment.authorType === "Bot"
+}
 
 /**
  * @typedef {{
@@ -38,6 +55,7 @@ import { CONTROL_PLANE_MARKERS, RUNTIME_REVIEW_MARKER } from "./runtime-review.j
  * @returns {PublishCommentPlan}
  */
 export function planPullRequestComment(comments, profile, runAttempt, renderOptions = {}) {
+    comments = comments.filter(isTrustedCommentAuthor)
     if (containsControlPlaneComment(comments)) {
         return {
             kind: "blocked-by-control-plane",

--- a/src/runtime-review.js
+++ b/src/runtime-review.js
@@ -600,10 +600,83 @@ export function edgeComparator(a, b) {
  */
 export function pullRequestURL(github) {
   const match = /^refs\/pull\/(\d+)\//.exec(String(github.ref || ""))
-  const repository = String(github.repository || "")
+  const repository = safeRepositorySlug(github.repository)
   if (match === null || repository === "") return ""
-  const server = String(github.server_url || "https://github.com").replace(/\/+$/, "")
+  const server = safeServerURL(github.server_url)
+  if (server === "") return ""
   return `${server}/${repository}/pull/${match[1]}`
+}
+
+// Record-derived values that land in Markdown/HTML link targets are
+// untrusted input: a forged profile could carry markup-breaking or
+// javascript: values. These normalizers fail closed to "" (the renderers
+// already degrade to unlinked text on empty URLs).
+
+/**
+ * A GitHub `owner/name` slug restricted to the characters GitHub allows;
+ * anything else returns "".
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function safeRepositorySlug(value) {
+  const repository = String(value || "")
+  return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository) ? repository : ""
+}
+
+/**
+ * A server base URL that parses as http(s) with no path, query, fragment,
+ * or credentials; anything else falls back to "".
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function safeServerURL(value) {
+  const raw = String(value || "https://github.com").replace(/\/+$/, "")
+  let parsed
+  try {
+    parsed = new URL(raw)
+  } catch (_) {
+    return ""
+  }
+  const isHTTP = parsed.protocol === "https:" || parsed.protocol === "http:"
+  const isBare =
+    parsed.pathname === "/" &&
+    parsed.search === "" &&
+    parsed.hash === "" &&
+    parsed.username === "" &&
+    parsed.password === ""
+  return isHTTP && isBare ? raw : ""
+}
+
+/**
+ * The run URL derived from validated record fields; "" when any part is
+ * untrusted or missing.
+ * @param {Record<string, any>} github
+ * @returns {string}
+ */
+function buildRunURL(github) {
+  const repository = safeRepositorySlug(github.repository)
+  const server = safeServerURL(github.server_url)
+  const runID = String(github.run_id || "")
+  if (repository === "" || server === "" || !/^\d+$/.test(runID)) return ""
+  return `${server}/${repository}/actions/runs/${runID}`
+}
+
+/**
+ * An absolute http(s) URL for use as a link target; anything else
+ * (including javascript: and data: schemes) returns "".
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function safeHTTPURL(value) {
+  const raw = String(value || "")
+  if (raw === "") return ""
+  let parsed
+  try {
+    parsed = new URL(raw)
+  } catch (_) {
+    return ""
+  }
+  return parsed.protocol === "https:" || parsed.protocol === "http:" ? raw : ""
 }
 
 /**
@@ -651,13 +724,10 @@ export function summarizeProfile(profile) {
   return {
     name: String(github.job || ""),
     workflow: String(github.workflow || ""),
-    repository: String(github.repository || ""),
+    repository: safeRepositorySlug(github.repository),
     sha: String(github.sha || ""),
     run_id: String(github.run_id || ""),
-    run_url:
-      github.run_id && github.repository
-        ? `${github.server_url || "https://github.com"}/${github.repository}/actions/runs/${github.run_id}`
-        : "",
+    run_url: buildRunURL(github),
     profile_id: String(envelope.id || envelope.profile_id || ""),
     uuid: String(p?.uuid || ""),
     timestamp: String(p?.timestamp || ""),
@@ -781,8 +851,8 @@ export function buildRunReview(input) {
       name: String(j.name || ""),
       workflow: String(j.workflow || ""),
       run_id: String(j.run_id || ""),
-      run_url: String(j.run_url || ""),
-      job_url: String(j.job_url || ""),
+      run_url: safeHTTPURL(j.run_url),
+      job_url: safeHTTPURL(j.job_url),
       profile_id: String(j.profile_id || ""),
       uuid: String(j.uuid || ""),
       timestamp: String(j.timestamp || ""),
@@ -2231,7 +2301,8 @@ function retentionOrder(edges) {
  */
 function commitRef(sha, commitUrl) {
   const sha7 = escapeCode(sha.slice(0, 7) || "unknown")
-  return commitUrl ? `[\`${sha7}\`](${commitUrl})` : `\`${sha7}\``
+  const url = safeHTTPURL(commitUrl)
+  return url !== "" ? `[\`${sha7}\`](${url})` : `\`${sha7}\``
 }
 
 /**

--- a/test/security-hardening.test.js
+++ b/test/security-hardening.test.js
@@ -1,0 +1,130 @@
+// Negative-path coverage for the security hardening surfaces: input
+// validation before values reach the release download URL or /etc/jibril,
+// untrusted comment-state authors, and record-derived Markdown/HTML link
+// targets.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { readFile } from "node:fs/promises"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { validateApiURL, validateJibrilVersion, validateNetworkPolicyYAML } from "../src/action.js"
+import { mergeCommentState, parseProfileJson, renderCommentBody } from "../src/profile-comment.js"
+import { planPullRequestComment } from "../src/pr-comment-plan.js"
+import {
+    CONTROL_PLANE_MARKERS,
+    pullRequestURL,
+    safeHTTPURL,
+    safeRepositorySlug,
+    safeServerURL,
+    summarizeProfile,
+} from "../src/runtime-review.js"
+
+const here = dirname(fileURLToPath(import.meta.url))
+const worthRaw = await readFile(join(here, "fixtures", "profiles", "worth-a-look-run.json"), "utf8")
+const worth = parseProfileJson(worthRaw)
+
+function stateBodyFor(profile) {
+    const merged = mergeCommentState(null, profile, 1)
+    assert.equal(merged.kind, "updated")
+    return renderCommentBody(merged.state)
+}
+
+test("jibril_version validation accepts release shapes", () => {
+    for (const version of ["latest", "v2.16.0", "2.16.0", "v0.0", "v2.10.4", "v2.17.0-rc.1"]) {
+        assert.equal(validateJibrilVersion(version), version)
+    }
+})
+
+test("jibril_version validation rejects URL-shaping values", () => {
+    const malicious = [
+        "../../../attacker/repo/releases/download/v1.0.0",
+        "v1.0.0/../../evil",
+        "v1.0.0?x=1",
+        "v1.0.0#frag",
+        "attacker/repo",
+        "latest/download/other",
+        "",
+        "v1.0.0 && curl evil",
+    ]
+    for (const version of malicious) {
+        assert.throws(() => validateJibrilVersion(version), /Invalid jibril_version/, version)
+    }
+})
+
+test("api_url validation requires https for remote hosts", () => {
+    assert.equal(validateApiURL("https://api.garnet.ai"), "https://api.garnet.ai")
+    assert.equal(validateApiURL("http://localhost:8080"), "http://localhost:8080")
+    assert.equal(validateApiURL("http://127.0.0.1:3000"), "http://127.0.0.1:3000")
+    assert.throws(() => validateApiURL("http://evil.example.com"), /must use https/)
+    assert.throws(() => validateApiURL("ftp://api.garnet.ai"), /must use https/)
+    assert.throws(() => validateApiURL("not a url"), /not a valid URL/)
+})
+
+test("network policy validation rejects empty, oversized, and binary content", () => {
+    const valid = "network_policy:\n  default_mode: alert\n"
+    assert.equal(validateNetworkPolicyYAML(valid), valid)
+    assert.throws(() => validateNetworkPolicyYAML(""), /empty/)
+    assert.throws(() => validateNetworkPolicyYAML("   \n"), /empty/)
+    assert.throws(() => validateNetworkPolicyYAML("a".repeat(1024 * 1024 + 1)), /size bound/)
+    assert.throws(() => validateNetworkPolicyYAML("rules:\n\u0000binary"), /control characters/)
+})
+
+test("comment state from a non-bot author is ignored", () => {
+    const body = stateBodyFor(worth)
+    const forged = [{ id: 1, body, authorLogin: "attacker", authorType: "User" }]
+    const plan = planPullRequestComment(forged, worth, 2)
+    assert.equal(plan.kind, "create")
+})
+
+test("comment state from a bot author is honored", () => {
+    const body = stateBodyFor(worth)
+    const trusted = [{ id: 1, body, authorLogin: "github-actions[bot]", authorType: "Bot" }]
+    const plan = planPullRequestComment(trusted, worth, 2)
+    assert.equal(plan.kind, "update")
+})
+
+test("a control-plane marker pasted by a human does not suppress publication", () => {
+    const comments = [
+        {
+            id: 1,
+            body: `<!-- ${CONTROL_PLANE_MARKERS[0]} -->\nforged CP comment`,
+            authorLogin: "attacker",
+            authorType: "User",
+        },
+    ]
+    const plan = planPullRequestComment(comments, worth, 1)
+    assert.equal(plan.kind, "create")
+})
+
+test("repository slug and server URL sinks fail closed", () => {
+    assert.equal(safeRepositorySlug("garnet-org/action"), "garnet-org/action")
+    assert.equal(safeRepositorySlug("evil/repo](javascript:alert(1))"), "")
+    assert.equal(safeRepositorySlug("a/b/c"), "")
+    assert.equal(safeServerURL("https://github.com"), "https://github.com")
+    assert.equal(safeServerURL("javascript:alert(1)//"), "")
+    assert.equal(safeServerURL("https://evil.com/path?x=1"), "")
+    assert.equal(safeHTTPURL("https://github.com/garnet-org/action"), "https://github.com/garnet-org/action")
+    assert.equal(safeHTTPURL("javascript:alert(1)"), "")
+    assert.equal(safeHTTPURL(""), "")
+})
+
+test("forged repository and server_url never reach a rendered link target", () => {
+    const summary = summarizeProfile({
+        github: {
+            job: "test",
+            repository: "evil](javascript:alert(1))",
+            server_url: "javascript:evil//",
+            run_id: "123",
+            ref: "refs/pull/7/merge",
+        },
+    })
+    assert.equal(summary.repository, "")
+    assert.equal(summary.run_url, "")
+    assert.equal(summary.pr_url, "")
+    assert.equal(
+        pullRequestURL({ ref: "refs/pull/7/merge", repository: "garnet-org/action", server_url: "https://github.com" }),
+        "https://github.com/garnet-org/action/pull/7",
+    )
+})


### PR DESCRIPTION
## Summary

Hardens the action against the remaining security-scan finding classes, rebased on main after #142 (binary trust: bundled tarball, Sigstore-signed checksums/manifest, `gh attestation verify`) and #145 (which fixed the attestation verify command itself — the predicate/signer-workflow fix this branch briefly carried was dropped in favor of main's). The earlier `src/jibril-verify.js` layer and `skip_signature_verification` input are gone as superseded; this PR now carries only what main does not cover:

**Input validation (P1 + P2)**
- `validateJibrilVersion` in `action.js`: `jibril_version` must be `latest` or `/^v?\d+\.\d+(\.\d+)?(-[A-Za-z0-9.]+)?$/`, checked before the value reaches the release download URL (`downloadJibril` interpolates the tag into the URL and archive name) — closes the path-traversal → attacker-URL download vector.
- `validateApiURL`: `api_url` must be `https:` (`http:` allowed for loopback only) — closes token egress over cleartext to arbitrary hosts.
- `validateNetworkPolicyYAML`: control-plane netpolicy is sanity-checked (non-empty, ≤1 MiB, no control chars) before being written under `/etc/jibril`.

**Comment trust (P1×2)**
- `GitHubIssueCommentClient.normalizeComment` now carries `authorLogin`/`authorType`; `planPullRequestComment` filters to bot-authored comments before honoring marker/base64url state or control-plane markers. A human pasting the marker can no longer suppress, stale-mark, or hijack the Runtime Review comment. Comments without author metadata stay trusted (fixture/back-compat; live listing always has `user`).
- Markdown/HTML sinks fail closed: `safeRepositorySlug` (strict `owner/name`), `safeServerURL` (bare-origin http(s) only), `safeHTTPURL` (http(s) only — kills `javascript:`/`data:`) gate `repository`, `run_url`, `pr_url`, `job_url`, and `commitRef` link targets. Renderers already degrade to unlinked text on `""`.

**Own workflows (P2)**
- `actions/checkout` / `actions/setup-node` pinned to full commit SHAs (`# vX.Y.Z` comments retained). The dynamic `garnet-org/action@$MAJOR_TAG` echo in `release.yaml` is release-notes text, not an executed pin.
- (Known residual: `post-artifacts.js` still uses a fixed `os.tmpdir()` subdir for the artifact staging copy — tracked separately; the root-privileged log copy itself goes through `sudo cp` into a dir the runner user owns.)

**Tests:** `test/security-hardening.test.js` — negative coverage for malicious versions, invalid `api_url`s, malformed netpolicy, forged comment/CP-marker state from non-bot authors, and `javascript:`-scheme link targets. `npm run validate` green (71/71); `dist/` rebuilt.

Intended to merge alongside the rest of the 2.3.0 stream before the stable release cut.

Link to Devin session: https://app.devin.ai/sessions/32aa07e63ccd43c3b25a31b00233a18b
Open in Devin Desktop: https://app.devin.ai/desktop/session/32aa07e63ccd43c3b25a31b00233a18b?variant=devin
Requested by: @jadoonf