### PR TITLE
feat: jibril stopped signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The same full-detail record is appended to the GitHub Actions Job Summary as the
 ## Under the hood
 
 - **Main step**: Downloads `jibril`, authenticates with the Garnet control plane via GitHub OIDC or `api_token`, fetches your merged network policy, and starts Jibril as a `systemd` service on the runner. If neither auth method is available the action falls back to a best-effort local review. If Jibril crashes during startup, the action logs diagnostics and continues so later workflow steps still run.
-- **Post step (always)**: Stops Jibril so it flushes events, appends the Garnet Execution Summary to `GITHUB_STEP_SUMMARY`, and creates or updates the pull request comment for the current push when the workflow runs for a PR. Multiple jobs and workflows from the same push merge into a single comment. When `debug=true`, it also uploads Jibril logs as build artifacts.
+- **Post step (always)**: Stops Jibril so it flushes events, appends the Garnet Execution Summary to `GITHUB_STEP_SUMMARY`, and creates or updates the pull request comment for the current push when the workflow runs for a PR. Multiple jobs and workflows from the same push merge into a single comment. If the shutdown flush exceeds the configured bound, the post step force stops the sensor so the job does not hang. When no usable Run Profile is produced, the action reports that stop to the control plane so pending comment state can be resolved. When `debug=true`, it also uploads Jibril logs as build artifacts.
 
 ---
 
@@ -191,6 +191,8 @@ The same full-detail record is appended to the GitHub Actions Job Summary as the
 | `github_token`      | No       | `${{ github.token }}`   | GitHub token used for pull request comments    |
 | `api_url`           | No       | `https://api.garnet.ai` | Garnet API base URL                            |
 | `jibril_version`    | No       | `""` (auto)             | Jibril version (for example `v2.16.0`, `v0.0`, or `latest`); empty resolves to the pinned stable release for your action ref (daily builds on `@v0`) |
+| `stop_timeout_seconds` | No    | `1800`                  | Maximum seconds Jibril gets at shutdown to finish writing the Run Profile and flushing events. The post step waits this long (plus a small grace), then force stops the sensor. Set to `0` or a negative integer to disable the timeout entirely. |
+
 | `debug`             | No       | `false`                 | Enable debug mode and upload logs as artifacts |
 | `preview`           | No       | `false`                 | Render the full-fidelity Step Summary record (assertions + evidence); preview shape is unstable and may change without a major version bump |
 

--- a/action.yaml
+++ b/action.yaml
@@ -34,6 +34,16 @@ inputs:
         description: "Render the full-fidelity Step Summary record (assertions + evidence). Preview shape is unstable and may change without a major version bump"
         required: false
         default: "false"
+    stop_timeout_seconds:
+        description: |
+            Maximum seconds Jibril is given at shutdown to finish writing its Run Profile and flushing
+            events. The post step waits this long (plus a small grace) and then force stops the sensor,
+            so a heavy backlog cannot stall the job indefinitely. Lower it to bound the post step;
+            raise it on long jobs where the profile matters more than post-step latency. Set to `0`
+            or a negative integer to disable the flush timeout entirely.
+        required: false
+        default: "1800"
+
 outputs:
     profile_result:
         description: "Reserved for the companion GitHub App and control plane; this action records the Runtime Review"

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -40954,6 +40954,44 @@ const API_ERROR_SCHEMA = object({
  * @property {ProfileEnvelope[]} items
  */
 
+/**
+ * @typedef {"run_cancelled" | "crashed" | "flush_timeout" | "stopped_cleanly"} AgentStopReason
+ */
+
+/**
+ * @typedef {"present" | "missing" | "empty" | "invalid"} AgentProfileState
+ */
+
+/**
+ * @typedef {"completed" | "timed_out"} AgentStopOutcome
+ */
+
+/**
+ * @typedef {"github_api"} JobStatusSource
+ */
+
+/**
+ * @typedef {object} AgentStoppedJibrilFields
+ * @property {string=} active_state
+ * @property {string=} result
+ * @property {number=} exec_main_status
+ * @property {AgentStopOutcome=} stop_outcome
+ * @property {boolean=} force_stopped
+ */
+
+/**
+ * @typedef {object} AgentStoppedRequest
+ * @property {AgentStopReason} reason
+ * @property {AgentProfileState} profile_state
+ * @property {string=} detail
+ * @property {string} run_id
+ * @property {string=} run_attempt
+ * @property {string=} job
+ * @property {string=} job_status
+ * @property {JobStatusSource=} job_status_source
+ * @property {AgentStoppedJibrilFields=} jibril
+ */
+
 const PROFILE_ENVELOPE_SCHEMA = object({
         id: schemas_string().min(1),
         runID: schemas_string().default(""),
@@ -40966,6 +41004,27 @@ const PROFILE_ENVELOPE_PAGE_SCHEMA = object({
     })
     .passthrough()
 
+const AGENT_STOP_REASON_SCHEMA = schemas_enum(["run_cancelled", "crashed", "flush_timeout", "stopped_cleanly"])
+
+const AGENT_STOPPED_REQUEST_SCHEMA = object({
+    reason: AGENT_STOP_REASON_SCHEMA,
+    profile_state: schemas_enum(["present", "missing", "empty", "invalid"]),
+    detail: schemas_string().optional(),
+    run_id: schemas_string().min(1),
+    run_attempt: schemas_string().min(1).optional(),
+    job: schemas_string().min(1).optional(),
+    job_status: schemas_string().min(1).optional(),
+    job_status_source: schemas_enum(["github_api"]).optional(),
+    jibril: object({
+            active_state: schemas_string().optional(),
+            result: schemas_string().optional(),
+            exec_main_status: schemas_number().int().optional(),
+            stop_outcome: schemas_enum(["completed", "timed_out"]).optional(),
+            force_stopped: schemas_boolean().optional(),
+        })
+        .optional(),
+})
+
 ;// CONCATENATED MODULE: ./src/control-plane/client.js
 
 
@@ -40975,6 +41034,7 @@ const PROFILE_ENVELOPE_PAGE_SCHEMA = object({
  * @typedef {import("./types.js").MergedNetPoliciesRequest} MergedNetPoliciesRequest
  * @typedef {import("./types.js").ExchangeOIDCResponse} ExchangeOIDCResponse
  * @typedef {import("./types.js").ProfileEnvelopePage} ProfileEnvelopePage
+ * @typedef {import("./types.js").AgentStoppedRequest} AgentStoppedRequest
  */
 
 /**
@@ -40989,6 +41049,7 @@ const PROFILE_ENVELOPE_PAGE_SCHEMA = object({
  *   baseURL: string
  *   projectToken?: string
  *   workflowToken?: string
+ *   agentToken?: string
  *   userAgent?: string
  * }} ControlPlaneClientOptions
  */
@@ -41001,6 +41062,7 @@ const PROFILE_ENVELOPE_PAGE_SCHEMA = object({
  *   body?: unknown
  *   accept?: string
  *   skipAuthHeader?: boolean
+ *   timeoutMs?: number
  * }} RequestOptions
  */
 
@@ -41051,9 +41113,14 @@ class ControlPlaneClient {
             throw new Error("ControlPlaneClient: 'workflowToken' must be a string when provided")
         }
 
+        if (options.agentToken !== undefined && typeof options.agentToken !== "string") {
+            throw new Error("ControlPlaneClient: 'agentToken' must be a string when provided")
+        }
+
         this.baseURL = parsedBaseURL.toString().replace(/\/+$/, "")
         this.projectToken = options.projectToken?.trim() ?? ""
         this.workflowToken = options.workflowToken?.trim() ?? ""
+        this.agentToken = options.agentToken?.trim() ?? ""
         this.userAgent = options.userAgent ?? "garnet-action"
     }
 
@@ -41118,6 +41185,24 @@ class ControlPlaneClient {
         })
 
         return PROFILE_ENVELOPE_PAGE_SCHEMA.parse(responseJson)
+    }
+
+    /**
+     * Signals that this run's sensor stopped, with the reason and whether a usable
+     * Run Profile was produced, so the control plane can resolve pending state.
+     * Authenticated as the agent itself.
+     * @param {AgentStoppedRequest} input
+     * @returns {Promise<void>}
+     */
+    async reportAgentStopped(input) {
+        const payload = AGENT_STOPPED_REQUEST_SCHEMA.parse(input)
+        // Keep the post step fast: one bounded best-effort request only.
+        await this.requestText({
+            method: "POST",
+            path: "/api/v1/agent/stopped",
+            body: payload,
+            timeoutMs: 10_000,
+        })
     }
 
     /**
@@ -41193,7 +41278,9 @@ class ControlPlaneClient {
         }
 
         if (options.skipAuthHeader !== true) {
-            if (this.workflowToken !== "") {
+            if (this.agentToken !== "") {
+                headers["X-Agent-Token"] = this.agentToken
+            } else if (this.workflowToken !== "") {
                 headers["X-Workflow-Token"] = this.workflowToken
             } else if (this.projectToken !== "") {
                 headers["X-Project-Token"] = this.projectToken
@@ -41204,38 +41291,39 @@ class ControlPlaneClient {
             headers["Content-Type"] = "application/json"
         }
 
+        /** @type {RequestInit} */
+        const requestInit = {
+            method: options.method,
+            headers,
+        }
+
+        if (options.body !== undefined) {
+            requestInit.body = JSON.stringify(options.body)
+        }
+
+        if (options.timeoutMs !== undefined) {
+            requestInit.signal = AbortSignal.timeout(options.timeoutMs)
+        }
+
         let response
         try {
-            if (options.body === undefined) {
-                response = await fetch(requestURL, {
-                    method: options.method,
-                    headers,
-                })
-            } else {
-                response = await fetch(requestURL, {
-                    method: options.method,
-                    headers,
-                    body: JSON.stringify(options.body),
-                })
-            }
+            response = await fetch(requestURL, requestInit)
         } catch (error) {
             const reason = error instanceof Error ? error.message : String(error)
-            throw new Error(
-                `Control plane request failed: ${options.method} ${options.path} (network error: ${reason})`,
-            )
+            throw new Error(`Control plane request failed: ${options.method} ${options.path} (network error: ${reason})`)
         }
 
         const responseText = await response.text()
-        if (!response.ok) {
-            const detail = getApiErrorDetail(responseText)
-            const statusDetail = detail === "" ? `HTTP ${response.status}` : `HTTP ${response.status}: ${detail}`
-            throw new Error(`Control plane request failed: ${options.method} ${options.path} (${statusDetail})`)
+        if (response.ok) {
+            return {
+                status: response.status,
+                responseText,
+            }
         }
 
-        return {
-            status: response.status,
-            responseText,
-        }
+        const detail = getApiErrorDetail(responseText)
+        const statusDetail = detail === "" ? `HTTP ${response.status}` : `HTTP ${response.status}: ${detail}`
+        throw new Error(`Control plane request failed: ${options.method} ${options.path} (${statusDetail})`)
     }
 }
 
@@ -41613,6 +41701,9 @@ async function run() {
         // The post step resolves the run's profile envelope ID from this agent.
         saveState("agentID", AGENT_ID)
 
+        // The post step authenticates as this agent to report stop reasons.
+        saveState("agentToken", AGENT_TOKEN)
+
         // Get network policy
         info("Getting network policy")
 
@@ -41736,11 +41827,15 @@ StandardOutput=append:/var/log/jibril.log
         await execSudo(["cp", loggingConfPath, "/etc/systemd/system/jibril.service.d/logging.conf"])
 
         // Raise the unit's stop ceiling so the shutdown event flush can
-        // complete and the JSON profile gets written on heavy jobs.
+        // complete and the JSON profile gets written on heavy jobs. A
+        // disabled bound is written as `infinity` rather than `0`: systemd
+        // only reads `0` as "no timeout" through a legacy compatibility
+        // path, and `0s` meant an immediate SIGKILL on some versions.
         const stopTimeoutSeconds = resolveStopTimeoutSeconds(getEnv(JIBRIL_STOP_TIMEOUT_ENV, ""))
-        info(`Configuring Jibril stop timeout (${stopTimeoutSeconds}s)`)
+        const stopTimeoutValue = stopTimeoutSeconds > 0 ? String(stopTimeoutSeconds) : "infinity"
+        info(`Configuring Jibril stop timeout (${stopTimeoutValue})`)
         const stopTimeoutConf = `[Service]
-TimeoutStopSec=${stopTimeoutSeconds}
+TimeoutStopSec=${stopTimeoutValue}
 `
         const stopTimeoutConfPath = external_node_path_namespaceObject.join(tmpDir, "stop-timeout.conf")
         await promises_namespaceObject.writeFile(stopTimeoutConfPath, stopTimeoutConf)
@@ -42318,19 +42413,23 @@ function parseReleaseManifest(manifestText) {
 
 /**
  * Resolves the stop ceiling written into the unit's drop-in. An explicit
- * positive-integer environment override wins; otherwise the default is used.
+ * integer wins, where zero or negative means "no bound at all"; anything
+ * unset or unparsable falls back to the default.
  * @param {string} overrideValue
- * @returns {number}
+ * @returns {number} seconds, or 0 when the bound is disabled
  */
 function resolveStopTimeoutSeconds(overrideValue) {
     const text = String(overrideValue === undefined || overrideValue === null ? "" : overrideValue).trim()
-    if (text !== "" && /^\d+$/.test(text)) {
-        const parsed = Number.parseInt(text, 10)
-        if (Number.isSafeInteger(parsed) && parsed > 0) {
-            return parsed
-        }
+    if (!/^-?\d+$/.test(text)) {
+        return DEFAULT_JIBRIL_STOP_TIMEOUT_SECONDS
     }
-    return DEFAULT_JIBRIL_STOP_TIMEOUT_SECONDS
+
+    const parsed = Number.parseInt(text, 10)
+    if (!Number.isSafeInteger(parsed)) {
+        return DEFAULT_JIBRIL_STOP_TIMEOUT_SECONDS
+    }
+
+    return parsed > 0 ? parsed : 0
 }
 
 /**
@@ -47388,6 +47487,16 @@ async function main() {
         process.env.GARNET_API_URL = getInput("api_url")
         process.env.JIBRIL_VERSION = getInput("jibril_version")
         process.env.DEBUG = getInput("debug")
+
+        // Resolve the shutdown flush bound once, here at the boundary: the
+        // main step writes it into the unit and the post step reuses the exact
+        // same number from state instead of re-deriving it. Zero means the
+        // bound is disabled.
+        const stopTimeoutSeconds = resolveStopTimeoutSeconds(
+            firstNonEmptyString(getInput("stop_timeout_seconds"), getEnv("GARNET_JIBRIL_STOP_TIMEOUT_SECONDS")),
+        )
+        process.env.GARNET_JIBRIL_STOP_TIMEOUT_SECONDS = String(stopTimeoutSeconds)
+        saveState("stopTimeoutSeconds", String(stopTimeoutSeconds))
 
         // The Run Profile permalink derives from the run id and the configured
         // API host, so it is known up front — emit the declared report_url output

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -40972,23 +40972,23 @@ const API_ERROR_SCHEMA = object({
 
 /**
  * @typedef {object} AgentStoppedJibrilFields
- * @property {string=} active_state
+ * @property {string=} activeState
  * @property {string=} result
- * @property {number=} exec_main_status
- * @property {AgentStopOutcome=} stop_outcome
- * @property {boolean=} force_stopped
+ * @property {number=} execMainStatus
+ * @property {AgentStopOutcome=} stopOutcome
+ * @property {boolean=} forceStopped
  */
 
 /**
  * @typedef {object} AgentStoppedRequest
  * @property {AgentStopReason} reason
- * @property {AgentProfileState} profile_state
+ * @property {AgentProfileState} profileState
  * @property {string=} detail
- * @property {string} run_id
- * @property {string=} run_attempt
+ * @property {string} runID
+ * @property {string=} runAttempt
  * @property {string=} job
- * @property {string=} job_status
- * @property {JobStatusSource=} job_status_source
+ * @property {"cancelled" | "failure"=} jobStatus
+ * @property {JobStatusSource=} jobStatusSource
  * @property {AgentStoppedJibrilFields=} jibril
  */
 
@@ -41008,19 +41008,19 @@ const AGENT_STOP_REASON_SCHEMA = schemas_enum(["run_cancelled", "crashed", "flus
 
 const AGENT_STOPPED_REQUEST_SCHEMA = object({
     reason: AGENT_STOP_REASON_SCHEMA,
-    profile_state: schemas_enum(["present", "missing", "empty", "invalid"]),
+    profileState: schemas_enum(["present", "missing", "empty", "invalid"]),
     detail: schemas_string().optional(),
-    run_id: schemas_string().min(1),
-    run_attempt: schemas_string().min(1).optional(),
+    runID: schemas_string().min(1),
+    runAttempt: schemas_string().min(1).optional(),
     job: schemas_string().min(1).optional(),
-    job_status: schemas_string().min(1).optional(),
-    job_status_source: schemas_enum(["github_api"]).optional(),
+    jobStatus: schemas_enum(["cancelled", "failure"]).optional(),
+    jobStatusSource: schemas_enum(["github_api"]).optional(),
     jibril: object({
-            active_state: schemas_string().optional(),
+            activeState: schemas_string().optional(),
             result: schemas_string().optional(),
-            exec_main_status: schemas_number().int().optional(),
-            stop_outcome: schemas_enum(["completed", "timed_out"]).optional(),
-            force_stopped: schemas_boolean().optional(),
+            execMainStatus: schemas_number().int().optional(),
+            stopOutcome: schemas_enum(["completed", "timed_out"]).optional(),
+            forceStopped: schemas_boolean().optional(),
         })
         .optional(),
 })

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -22232,7 +22232,7 @@ module.exports = isStream;
 
 /***/ }),
 
-/***/ 4894:
+/***/ 2513:
 /***/ ((module) => {
 
 var toString = {}.toString;
@@ -22529,7 +22529,7 @@ var pna = __nccwpck_require__(1564);
 module.exports = Readable;
 
 /*<replacement>*/
-var isArray = __nccwpck_require__(4894);
+var isArray = __nccwpck_require__(2513);
 /*</replacement>*/
 
 /*<replacement>*/
@@ -81289,7 +81289,7 @@ const external_node_os_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import
  * @param {string=} def
  * @returns {string}
  */
-function getEnv(name, def = "") {
+function shared_getEnv(name, def = "") {
   return process.env[name] ?? def
 }
 
@@ -81427,7 +81427,7 @@ async function getPullRequestNumberFromEvent(eventPath) {
  * @param {string} eventPath
  * @returns {Promise<string | null>}
  */
-async function getPullRequestHeadShaFromEvent(eventPath) {
+async function github_event_getPullRequestHeadShaFromEvent(eventPath) {
   try {
     const payload = await readGitHubEventPayload(eventPath)
     if (payload === null) {
@@ -81449,6 +81449,81 @@ async function getPullRequestHeadShaFromEvent(eventPath) {
 async function readGitHubEventPayload(eventPath) {
   const payload = JSON.parse(await promises_.readFile(eventPath, "utf8"))
   return isRecord(payload) ? payload : null
+}
+
+;// CONCATENATED MODULE: ./src/github-context.js
+
+
+
+/**
+ * @returns {string}
+ */
+function getProfileJobName() {
+  return shared_getEnv("GARNET_PROFILE_JOB", shared_getEnv("GITHUB_JOB"))
+}
+
+/**
+ * @returns {Promise<Record<string, string>>}
+ */
+async function createGitHubContext() {
+  return {
+    job: getProfileJobName(),
+    run_id: getEnv("GITHUB_RUN_ID"),
+    workflow: getProfileWorkflowName(),
+    repository: getEnv("GITHUB_REPOSITORY"),
+    repository_id: getEnv("GITHUB_REPOSITORY_ID"),
+    repository_owner: getEnv("GITHUB_REPOSITORY_OWNER"),
+    repository_owner_id: getEnv("GITHUB_REPOSITORY_OWNER_ID"),
+    event_name: getEnv("GITHUB_EVENT_NAME"),
+    ref: getEnv("GITHUB_REF"),
+    sha: await getProfileSha(),
+    actor: getEnv("GITHUB_ACTOR"),
+    runner_os: getEnv("RUNNER_OS"),
+    runner_arch: getEnv("RUNNER_ARCH"),
+  }
+}
+
+/**
+ * @returns {string}
+ */
+function getWorkflowFilePath() {
+  const workspace = getEnv("GITHUB_WORKSPACE")
+  const workflowRef = getEnv("GITHUB_WORKFLOW_REF")
+  const repository = getEnv("GITHUB_REPOSITORY")
+
+  if (workspace === "" || workflowRef === "" || repository === "") {
+    return ""
+  }
+
+  const pathPart = workflowRef.split("@")[0] ?? ""
+  const repoPrefix = `${repository}/`
+  const relativePath = pathPart.startsWith(repoPrefix)
+    ? pathPart.slice(repoPrefix.length)
+    : pathPart
+
+  return `${workspace}/${relativePath}`
+}
+
+/**
+ * @returns {string}
+ */
+function getProfileWorkflowName() {
+  return getEnv("GARNET_PROFILE_WORKFLOW", getEnv("GITHUB_WORKFLOW"))
+}
+
+/**
+ * @returns {Promise<string>}
+ */
+async function getProfileSha() {
+  const eventPath = getEnv("GITHUB_EVENT_PATH")
+  if (eventPath !== "") {
+    const pullRequestHeadSha = await getPullRequestHeadShaFromEvent(eventPath)
+    if (pullRequestHeadSha !== null) {
+      return pullRequestHeadSha
+    }
+  }
+
+  return getEnv("GITHUB_SHA")
 }
 
 ;// CONCATENATED MODULE: ./node_modules/zod/v4/core/util.js
@@ -90790,6 +90865,44 @@ const API_ERROR_SCHEMA = object({
  * @property {ProfileEnvelope[]} items
  */
 
+/**
+ * @typedef {"run_cancelled" | "crashed" | "flush_timeout" | "stopped_cleanly"} AgentStopReason
+ */
+
+/**
+ * @typedef {"present" | "missing" | "empty" | "invalid"} AgentProfileState
+ */
+
+/**
+ * @typedef {"completed" | "timed_out"} AgentStopOutcome
+ */
+
+/**
+ * @typedef {"github_api"} JobStatusSource
+ */
+
+/**
+ * @typedef {object} AgentStoppedJibrilFields
+ * @property {string=} active_state
+ * @property {string=} result
+ * @property {number=} exec_main_status
+ * @property {AgentStopOutcome=} stop_outcome
+ * @property {boolean=} force_stopped
+ */
+
+/**
+ * @typedef {object} AgentStoppedRequest
+ * @property {AgentStopReason} reason
+ * @property {AgentProfileState} profile_state
+ * @property {string=} detail
+ * @property {string} run_id
+ * @property {string=} run_attempt
+ * @property {string=} job
+ * @property {string=} job_status
+ * @property {JobStatusSource=} job_status_source
+ * @property {AgentStoppedJibrilFields=} jibril
+ */
+
 const PROFILE_ENVELOPE_SCHEMA = object({
         id: schemas_string().min(1),
         runID: schemas_string().default(""),
@@ -90802,6 +90915,27 @@ const PROFILE_ENVELOPE_PAGE_SCHEMA = object({
     })
     .passthrough()
 
+const AGENT_STOP_REASON_SCHEMA = schemas_enum(["run_cancelled", "crashed", "flush_timeout", "stopped_cleanly"])
+
+const AGENT_STOPPED_REQUEST_SCHEMA = object({
+    reason: AGENT_STOP_REASON_SCHEMA,
+    profile_state: schemas_enum(["present", "missing", "empty", "invalid"]),
+    detail: schemas_string().optional(),
+    run_id: schemas_string().min(1),
+    run_attempt: schemas_string().min(1).optional(),
+    job: schemas_string().min(1).optional(),
+    job_status: schemas_string().min(1).optional(),
+    job_status_source: schemas_enum(["github_api"]).optional(),
+    jibril: object({
+            active_state: schemas_string().optional(),
+            result: schemas_string().optional(),
+            exec_main_status: schemas_number().int().optional(),
+            stop_outcome: schemas_enum(["completed", "timed_out"]).optional(),
+            force_stopped: schemas_boolean().optional(),
+        })
+        .optional(),
+})
+
 ;// CONCATENATED MODULE: ./src/control-plane/client.js
 
 
@@ -90811,6 +90945,7 @@ const PROFILE_ENVELOPE_PAGE_SCHEMA = object({
  * @typedef {import("./types.js").MergedNetPoliciesRequest} MergedNetPoliciesRequest
  * @typedef {import("./types.js").ExchangeOIDCResponse} ExchangeOIDCResponse
  * @typedef {import("./types.js").ProfileEnvelopePage} ProfileEnvelopePage
+ * @typedef {import("./types.js").AgentStoppedRequest} AgentStoppedRequest
  */
 
 /**
@@ -90825,6 +90960,7 @@ const PROFILE_ENVELOPE_PAGE_SCHEMA = object({
  *   baseURL: string
  *   projectToken?: string
  *   workflowToken?: string
+ *   agentToken?: string
  *   userAgent?: string
  * }} ControlPlaneClientOptions
  */
@@ -90837,6 +90973,7 @@ const PROFILE_ENVELOPE_PAGE_SCHEMA = object({
  *   body?: unknown
  *   accept?: string
  *   skipAuthHeader?: boolean
+ *   timeoutMs?: number
  * }} RequestOptions
  */
 
@@ -90887,9 +91024,14 @@ class ControlPlaneClient {
             throw new Error("ControlPlaneClient: 'workflowToken' must be a string when provided")
         }
 
+        if (options.agentToken !== undefined && typeof options.agentToken !== "string") {
+            throw new Error("ControlPlaneClient: 'agentToken' must be a string when provided")
+        }
+
         this.baseURL = parsedBaseURL.toString().replace(/\/+$/, "")
         this.projectToken = options.projectToken?.trim() ?? ""
         this.workflowToken = options.workflowToken?.trim() ?? ""
+        this.agentToken = options.agentToken?.trim() ?? ""
         this.userAgent = options.userAgent ?? "garnet-action"
     }
 
@@ -90954,6 +91096,24 @@ class ControlPlaneClient {
         })
 
         return PROFILE_ENVELOPE_PAGE_SCHEMA.parse(responseJson)
+    }
+
+    /**
+     * Signals that this run's sensor stopped, with the reason and whether a usable
+     * Run Profile was produced, so the control plane can resolve pending state.
+     * Authenticated as the agent itself.
+     * @param {AgentStoppedRequest} input
+     * @returns {Promise<void>}
+     */
+    async reportAgentStopped(input) {
+        const payload = AGENT_STOPPED_REQUEST_SCHEMA.parse(input)
+        // Keep the post step fast: one bounded best-effort request only.
+        await this.requestText({
+            method: "POST",
+            path: "/api/v1/agent/stopped",
+            body: payload,
+            timeoutMs: 10_000,
+        })
     }
 
     /**
@@ -91029,7 +91189,9 @@ class ControlPlaneClient {
         }
 
         if (options.skipAuthHeader !== true) {
-            if (this.workflowToken !== "") {
+            if (this.agentToken !== "") {
+                headers["X-Agent-Token"] = this.agentToken
+            } else if (this.workflowToken !== "") {
                 headers["X-Workflow-Token"] = this.workflowToken
             } else if (this.projectToken !== "") {
                 headers["X-Project-Token"] = this.projectToken
@@ -91040,38 +91202,39 @@ class ControlPlaneClient {
             headers["Content-Type"] = "application/json"
         }
 
+        /** @type {RequestInit} */
+        const requestInit = {
+            method: options.method,
+            headers,
+        }
+
+        if (options.body !== undefined) {
+            requestInit.body = JSON.stringify(options.body)
+        }
+
+        if (options.timeoutMs !== undefined) {
+            requestInit.signal = AbortSignal.timeout(options.timeoutMs)
+        }
+
         let response
         try {
-            if (options.body === undefined) {
-                response = await fetch(requestURL, {
-                    method: options.method,
-                    headers,
-                })
-            } else {
-                response = await fetch(requestURL, {
-                    method: options.method,
-                    headers,
-                    body: JSON.stringify(options.body),
-                })
-            }
+            response = await fetch(requestURL, requestInit)
         } catch (error) {
             const reason = error instanceof Error ? error.message : String(error)
-            throw new Error(
-                `Control plane request failed: ${options.method} ${options.path} (network error: ${reason})`,
-            )
+            throw new Error(`Control plane request failed: ${options.method} ${options.path} (network error: ${reason})`)
         }
 
         const responseText = await response.text()
-        if (!response.ok) {
-            const detail = getApiErrorDetail(responseText)
-            const statusDetail = detail === "" ? `HTTP ${response.status}` : `HTTP ${response.status}: ${detail}`
-            throw new Error(`Control plane request failed: ${options.method} ${options.path} (${statusDetail})`)
+        if (response.ok) {
+            return {
+                status: response.status,
+                responseText,
+            }
         }
 
-        return {
-            status: response.status,
-            responseText,
-        }
+        const detail = getApiErrorDetail(responseText)
+        const statusDetail = detail === "" ? `HTTP ${response.status}` : `HTTP ${response.status}: ${detail}`
+        throw new Error(`Control plane request failed: ${options.method} ${options.path} (${statusDetail})`)
     }
 }
 
@@ -148705,8 +148868,8 @@ async function findExistingArtifactFiles(artifactDir, fileNames) {
  * @returns {string}
  */
 function getDebugArtifactName() {
-  const jobName = getEnv("GITHUB_JOB")
-  const runAttempt = getEnv("GITHUB_RUN_ATTEMPT")
+  const jobName = shared_getEnv("GITHUB_JOB")
+  const runAttempt = shared_getEnv("GITHUB_RUN_ATTEMPT")
 
   const artifactNameParts = [DEBUG_ARTIFACT_NAME]
   if (jobName !== "") {
@@ -154183,7 +154346,410 @@ function parseSystemdTimespanSeconds(value) {
     return rounded
 }
 
+;// CONCATENATED MODULE: ./src/post-profile-state.js
+
+
+
+/** @typedef {import("./profile-comment.js").NormalizedProfile} NormalizedProfile */
+
+/**
+ * @typedef {object} RootFileStat
+ * @property {boolean} exists
+ * @property {number} size
+ */
+
+/**
+ * @typedef {object} LoadedProfile
+ * @property {NormalizedProfile} normalized
+ * @property {unknown} raw
+ */
+
+/**
+ * @typedef {"present" | "missing" | "empty" | "invalid"} ProfileState
+ */
+
+/**
+ * @typedef {object} ProfileResult
+ * @property {ProfileState} state
+ * @property {LoadedProfile | null} profile
+ * @property {string} detail
+ */
+
+/**
+ * @param {RootFileStat} stat
+ * @param {string} content
+ * @returns {ProfileResult}
+ */
+function classifyProfileContent(stat, content) {
+    if (!stat.exists) {
+        return {
+            state: "missing",
+            profile: null,
+            detail: "profile file missing",
+        }
+    }
+
+    if (stat.size === 0) {
+        return {
+            state: "empty",
+            profile: null,
+            detail: "profile file empty",
+        }
+    }
+
+    if (content.trim() === "") {
+        return {
+            state: "empty",
+            profile: null,
+            detail: "profile file empty",
+        }
+    }
+
+    try {
+        const normalized = parseProfileJson(content)
+        const raw = JSON.parse(content)
+
+        return {
+            state: "present",
+            profile: {
+                normalized,
+                raw,
+            },
+            detail: "",
+        }
+    } catch (error) {
+        return {
+            state: "invalid",
+            profile: null,
+            detail: getErrorMessage(error),
+        }
+    }
+}
+
+;// CONCATENATED MODULE: ./src/post-signal.js
+/** @typedef {import("./post-profile-state.js").ProfileState} ProfileState */
+
+/**
+ * @typedef {object} JibrilUnitState
+ * @property {string} activeState
+ * @property {string} result
+ * @property {number} execMainStatus
+ */
+
+/**
+ * @typedef {object} AgentStopEvidence
+ * @property {string} jobStatus
+ * @property {JibrilUnitState | null} unitStateBeforeStop
+ * @property {JibrilUnitState | null} unitStateAfterStop
+ * @property {"completed" | "timed_out"} stopOutcome
+ * @property {boolean} forceStopped
+ * @property {number} stopTimeoutSeconds
+ * @property {ProfileState} profileState
+ */
+
+/**
+ * @typedef {"run_cancelled" | "crashed" | "flush_timeout" | "stopped_cleanly"} AgentStopReason
+ */
+
+/**
+ * @param {AgentStopEvidence} evidence
+ * @returns {AgentStopReason}
+ */
+function classifyAgentStop(evidence) {
+    const status = evidence.jobStatus.trim().toLowerCase()
+    if (status === "cancelled" || status === "canceled") {
+        return "run_cancelled"
+    }
+
+    const before = evidence.unitStateBeforeStop
+    if (before !== null) {
+        const hasFailureState = before.activeState === "failed"
+        const hasInactiveFailure = before.activeState === "inactive" && before.result !== "success"
+        const hasNonZeroStatus = before.execMainStatus !== 0
+        if (hasFailureState || hasInactiveFailure || hasNonZeroStatus) {
+            return "crashed"
+        }
+    }
+
+    if (evidence.stopOutcome === "timed_out") {
+        return "flush_timeout"
+    }
+
+    return "stopped_cleanly"
+}
+
+/**
+ * @param {AgentStopEvidence} evidence
+ * @returns {string}
+ */
+function formatAgentStopDetail(evidence) {
+    /** @type {string[]} */
+    const parts = []
+
+    if (evidence.stopOutcome === "timed_out") {
+        parts.push(`stop timed out after ${evidence.stopTimeoutSeconds}s`)
+    } else {
+        parts.push("stop completed")
+    }
+
+    if (evidence.forceStopped) {
+        parts.push("unit SIGKILLed")
+    }
+
+    parts.push(getProfileStateDetail(evidence.profileState))
+
+    return parts.join("; ")
+}
+
+/**
+ * @param {ProfileState} profileState
+ * @returns {string}
+ */
+function getProfileStateDetail(profileState) {
+    if (profileState === "missing") {
+        return "profile file missing"
+    }
+    if (profileState === "empty") {
+        return "profile file empty"
+    }
+    if (profileState === "invalid") {
+        return "profile JSON invalid"
+    }
+    return "profile present"
+}
+
+;// CONCATENATED MODULE: ./src/github-job-status.js
+
+
+
+
+/**
+ * @typedef {object} JobStatusResolution
+ * @property {string} status
+ * @property {"github_api" | "unknown"} source
+ */
+
+/**
+ * @typedef {object} JobStatusLookup
+ * @property {string} token
+ * @property {string} repository
+ * @property {string} runID
+ * @property {string} runAttempt
+ * @property {string} runnerName
+ * @property {string} jobName
+ */
+
+/**
+ * @typedef {object} WorkflowRunJobStep
+ * @property {string | null=} conclusion
+ */
+
+/**
+ * @typedef {object} WorkflowRunJob
+ * @property {string | null=} name
+ * @property {string | null=} runner_name
+ * @property {string=} status
+ * @property {string | null=} conclusion
+ * @property {WorkflowRunJobStep[]=} steps
+ */
+
+/**
+ * Best-effort: resolves the current job's status from the workflow run's job
+ * list. Fail-closed — any missing permission, ambiguity, or request failure
+ * resolves to an empty status.
+ * @param {JobStatusLookup} lookup
+ * @returns {Promise<JobStatusResolution>}
+ */
+async function resolveJobStatusFromGitHub(lookup) {
+    const token = lookup.token.trim()
+    const repository = lookup.repository.trim()
+    const runID = lookup.runID.trim()
+    const runAttempt = lookup.runAttempt.trim()
+
+    if (token === "" || repository === "" || runID === "" || runAttempt === "") {
+        return { status: "", source: "unknown" }
+    }
+
+    const [owner = "", repo = ""] = repository.split("/")
+    if (owner === "" || repo === "") {
+        return { status: "", source: "unknown" }
+    }
+
+    const attemptNumber = Number.parseInt(runAttempt, 10)
+    if (!Number.isSafeInteger(attemptNumber) || attemptNumber <= 0) {
+        return { status: "", source: "unknown" }
+    }
+
+    const numericRunID = Number.parseInt(runID, 10)
+    if (!Number.isSafeInteger(numericRunID) || numericRunID <= 0) {
+        return { status: "", source: "unknown" }
+    }
+
+    try {
+        const octokit = getOctokit(token)
+        const response = await octokit.rest.actions.listJobsForWorkflowRunAttempt({
+            owner,
+            repo,
+            run_id: numericRunID,
+            attempt_number: attemptNumber,
+            per_page: 100,
+            request: {
+                signal: AbortSignal.timeout(5000),
+            },
+        })
+
+        const jobs = response.data.jobs
+        const status = deriveJobStatusFromJobs(jobs, {
+            runnerName: lookup.runnerName,
+            jobName: lookup.jobName,
+        })
+        if (status === "") {
+            return { status: "", source: "unknown" }
+        }
+
+        return { status, source: "github_api" }
+    } catch (error) {
+        const statusCode = github_job_status_getStatusCode(error)
+        if (statusCode === 403 || statusCode === 404) {
+            info(`job-status GitHub API probe skipped: HTTP ${statusCode}`)
+            return { status: "", source: "unknown" }
+        }
+
+        info(`job-status GitHub API probe skipped: ${getErrorMessage(error)}`)
+        return { status: "", source: "unknown" }
+    }
+}
+
+/**
+ * @param {WorkflowRunJob[]} jobs
+ * @param {{ runnerName: string, jobName: string }} selector
+ * @returns {string}
+ */
+function deriveJobStatusFromJobs(jobs, selector) {
+    const runnerMatches = jobs.filter(job => job.runner_name === selector.runnerName && job.status === "in_progress")
+
+    if (runnerMatches.length === 1) {
+        const match = runnerMatches[0]
+        if (match !== undefined) {
+            return deriveJobStatusFromJob(match)
+        }
+    }
+
+    const nameMatches = jobs.filter(job => job.name === selector.jobName)
+    if (nameMatches.length === 1) {
+        const match = nameMatches[0]
+        if (match !== undefined) {
+            return deriveJobStatusFromJob(match)
+        }
+    }
+
+    return ""
+}
+
+/**
+ * @param {WorkflowRunJob} job
+ * @returns {string}
+ */
+function deriveJobStatusFromJob(job) {
+    if (job.conclusion === "cancelled") {
+        return "cancelled"
+    }
+
+    const steps = Array.isArray(job.steps) ? job.steps : []
+    for (const step of steps) {
+        if (step.conclusion === "cancelled") {
+            return "cancelled"
+        }
+    }
+
+    for (const step of steps) {
+        if (step.conclusion === "failure") {
+            return "failure"
+        }
+    }
+
+    return ""
+}
+
+/**
+ * @param {unknown} error
+ * @returns {number}
+ */
+function github_job_status_getStatusCode(error) {
+    if (typeof error !== "object" || error === null) {
+        return 0
+    }
+
+    const maybeError = /** @type {{ status?: unknown }} */ (error)
+    return typeof maybeError.status === "number" ? maybeError.status : 0
+}
+
+;// CONCATENATED MODULE: ./src/post-stop-timeout.js
+// Resolution of the post step's `systemctl stop` bound. Zero means the bound
+// is disabled and the post step waits for the flush without a ceiling.
+
+const FALLBACK_STOP_TIMEOUT_SECONDS = 1800
+const STOP_TIMEOUT_GRACE_SECONDS = 30
+
+/**
+ * @typedef {object} StopTimeoutSettings
+ * @property {string} envOverride
+ * @property {string} savedState
+ */
+
+/**
+ * Resolves the bound from the values the action itself controls: the env
+ * escape hatch (used verbatim) then the ceiling the main step saved. Returns
+ * null when neither is set, so the caller knows it still has to ask the unit.
+ * @param {StopTimeoutSettings} settings
+ * @returns {number | null} seconds, 0 when disabled, null when unresolved
+ */
+function resolveStopTimeoutFromSettings(settings) {
+    const envOverride = parseTimeoutSetting(settings.envOverride)
+    if (envOverride !== null) {
+        return envOverride > 0 ? envOverride : 0
+    }
+
+    const savedState = parseTimeoutSetting(settings.savedState)
+    if (savedState !== null) {
+        return savedState > 0 ? savedState + STOP_TIMEOUT_GRACE_SECONDS : 0
+    }
+
+    return null
+}
+
+/**
+ * Resolves the bound for runs whose saved state predates `stopTimeoutSeconds`,
+ * from the unit's own TimeoutStopSec. An unreadable or infinite unit value
+ * keeps the historical fallback rather than removing the ceiling entirely.
+ * @param {number | null} unitTimeoutSeconds
+ * @returns {number} seconds
+ */
+function resolveStopTimeoutFromUnit(unitTimeoutSeconds) {
+    const seconds = unitTimeoutSeconds === null ? FALLBACK_STOP_TIMEOUT_SECONDS : unitTimeoutSeconds
+    return seconds + STOP_TIMEOUT_GRACE_SECONDS
+}
+
+/**
+ * @param {string} value
+ * @returns {number | null}
+ */
+function parseTimeoutSetting(value) {
+    const text = value.trim()
+    if (!/^-?\d+$/.test(text)) {
+        return null
+    }
+
+    const parsedValue = Number.parseInt(text, 10)
+    return Number.isSafeInteger(parsedValue) ? parsedValue : null
+}
+
 ;// CONCATENATED MODULE: ./src/post.js
+
+
+
+
+
 
 
 
@@ -154201,9 +154767,26 @@ function parseSystemdTimespanSeconds(value) {
 
 /** @typedef {import("./profile-comment.js").NormalizedProfile} NormalizedProfile */
 /** @typedef {import("./profile-comment.js").RenderOptions} RenderOptions */
+/** @typedef {import("./post-profile-state.js").LoadedProfile} LoadedProfile */
+/** @typedef {import("./post-profile-state.js").ProfileResult} ProfileResult */
+/** @typedef {import("./post-profile-state.js").RootFileStat} RootFileStat */
+/** @typedef {import("./post-signal.js").JibrilUnitState} JibrilUnitState */
+/** @typedef {import("./post-signal.js").AgentStopEvidence} AgentStopEvidence */
+/** @typedef {import("./github-job-status.js").JobStatusResolution} JobStatusResolution */
+/** @typedef {import("./control-plane/types.js").AgentStoppedRequest} AgentStoppedRequest */
+/** @typedef {import("./control-plane/types.js").AgentStoppedJibrilFields} AgentStoppedJibrilFields */
 
 /**
- * @typedef {{ normalized: NormalizedProfile, raw: unknown }} LoadedProfile
+ * Everything the post step observed about how the sensor stopped, from which
+ * the control-plane signal is derived.
+ * @typedef {object} AgentStopObservations
+ * @property {string} agentToken
+ * @property {JibrilUnitState | null} unitStateBeforeStop
+ * @property {JibrilUnitState | null} unitStateAfterStop
+ * @property {"completed" | "timed_out"} stopOutcome
+ * @property {boolean} forceStopped
+ * @property {number} stopTimeoutSeconds
+ * @property {ProfileResult} profileResult
  */
 
 /**
@@ -154223,11 +154806,11 @@ const DOCS_URL = "https://github.com/garnet-org/action#readme"
 // past it), so the post
 // step waits for the stop to complete — aligned to the unit's own deadline
 // plus a small grace — rather than abandoning a still-deactivating service
-// and losing the profile. The bound stays overridable for consumers that
-// prefer a shorter post step over profile capture on heavy jobs.
+// and losing the profile. The `stop_timeout_seconds` input is the supported
+// knob; this env var stays as an advanced escape hatch and is used verbatim.
 const STOP_TIMEOUT_ENV = "GARNET_POST_STOP_TIMEOUT_SECONDS"
-const FALLBACK_STOP_TIMEOUT_SECONDS = 1800
-const STOP_TIMEOUT_GRACE_SECONDS = 30
+const STOP_TIMEOUT_INPUT = "stop_timeout_seconds"
+
 const PROFILE_WAIT_ENV = "GARNET_POST_PROFILE_WAIT_SECONDS"
 const DEFAULT_PROFILE_WAIT_SECONDS = 60
 const PROFILE_POLL_INTERVAL_MS = 5000
@@ -154256,6 +154839,13 @@ async function run() {
 
     try {
         const jibrilStarted = getState("jibrilStarted") === "true"
+        const agentID = getState("agentID")
+        const agentToken = getState("agentToken")
+        const jsonProfilerFile = firstNonEmptyString(getState("jsonProfilerFile"), getDefaultJsonProfileFile())
+
+        if (agentToken !== "") {
+            setSecret(agentToken)
+        }
 
         // Remove secrets from disk (best-effort). Important for self-hosted runners.
         await exec_exec("sudo", ["rm", "-f", "/etc/default/jibril"], {
@@ -154267,29 +154857,36 @@ async function run() {
             return
         }
 
-        const jsonProfilerFile = firstNonEmptyString(getState("jsonProfilerFile"), getDefaultJsonProfileFile())
+        // Read before the stop as well: it is the only way to tell a sensor
+        // that had already crashed from one we timed out waiting on.
+        const unitStateBeforeStop = await readJibrilUnitState()
+        logJibrilUnitState("jibril service state before stop", unitStateBeforeStop)
 
         // Stop the Jibril service and wait for the stop to complete so the
         // daemon flushes all pending events and writes the JSON profile. The
         // wait is aligned to the unit's own stop deadline (TimeoutStopSec)
         // plus a grace period, because the profile is written only when the
         // flush completes: abandoning a still-deactivating service loses it.
-        const stopTimeoutSeconds = await resolveStopTimeoutSeconds()
+        const stopTimeoutSeconds = await resolvePostStopTimeoutSeconds()
+        let stopArgs = ["systemctl", "stop", "jibril.service"]
+        if (stopTimeoutSeconds > 0) {
+            stopArgs = ["timeout", `${stopTimeoutSeconds}s`, ...stopArgs]
+            info(`stopping jibril service (waiting up to ${stopTimeoutSeconds}s for the event flush to complete)`)
+        } else {
+            info("stopping jibril service (flush bound disabled, waiting for the event flush to complete)")
+        }
+
         const stopStart = Date.now()
-        info(`stopping jibril service (waiting up to ${stopTimeoutSeconds}s for the event flush to complete)`)
-        const stopExitCode = await exec_exec(
-            "sudo",
-            ["timeout", `${stopTimeoutSeconds}s`, "systemctl", "stop", "jibril.service"],
-            {
-                ignoreReturnCode: true,
-            },
-        )
+        const stopExitCode = await exec_exec("sudo", stopArgs, {
+            ignoreReturnCode: true,
+        })
+        const stopOutcome = stopExitCode === STOP_TIMED_OUT_EXIT_CODE ? "timed_out" : "completed"
         info(`jibril service stop finished in ${Math.round((Date.now() - stopStart) / 1000)}s`)
 
-        const profileWaitSeconds = parsePositiveInteger(getEnv(PROFILE_WAIT_ENV), DEFAULT_PROFILE_WAIT_SECONDS)
-        if (stopExitCode === STOP_TIMED_OUT_EXIT_CODE) {
+        const profileWaitSeconds = parsePositiveInteger(shared_getEnv(PROFILE_WAIT_ENV), DEFAULT_PROFILE_WAIT_SECONDS)
+        if (stopOutcome === "timed_out") {
             info(
-                `jibril was still flushing its event backlog after ${stopTimeoutSeconds}s (set ${STOP_TIMEOUT_ENV} to change the bound); ` +
+                `jibril was still flushing its event backlog after ${stopTimeoutSeconds}s (set the ${STOP_TIMEOUT_INPUT} input to change the bound); ` +
                     `waiting up to ${profileWaitSeconds}s more for the ${JSON_PROFILE_LABEL} at ${jsonProfilerFile}`,
             )
         }
@@ -154305,7 +154902,14 @@ async function run() {
             )
         }
 
-        await logJibrilServiceState()
+        let forceStopped = false
+        if (stopOutcome === "timed_out") {
+            await forceStopJibril()
+            forceStopped = true
+        }
+
+        const unitStateAfterStop = await readJibrilUnitState()
+        logJibrilUnitState("jibril service state", unitStateAfterStop)
 
         // Upload jibril logs as artifacts when debug is enabled (only after service stops).
         // Get the debug state from the main.js.
@@ -154314,17 +154918,32 @@ async function run() {
             await uploadJibrilArtifacts()
         }
 
-        const profile = await readProfile(jsonProfilerFile, debug === "true")
+        const profileResult = await readProfile(jsonProfilerFile, debug === "true")
         const renderOptions = getRenderOptions()
 
+        const profile = profileResult.profile
         if (profile !== null) {
-            const envelopeID = await resolveProfileEnvelopeID()
+            const envelopeID = await resolveProfileEnvelopeID(agentID)
             if (envelopeID !== "") {
                 // The raw on-disk Jibril profile has no control-plane envelope
                 // ID; wrapping it threads the ID into every render so the
                 // exact public profile selector resolves.
                 profile.raw = { id: envelopeID, data: profile.raw }
             }
+        }
+
+        // A run that produced no usable profile leaves the control plane's
+        // pending state unresolved, so the agent reports how it stopped.
+        if (profileResult.state !== "present" && agentToken !== "") {
+            await reportAgentStop({
+                agentToken,
+                unitStateBeforeStop,
+                unitStateAfterStop,
+                stopOutcome,
+                forceStopped,
+                stopTimeoutSeconds,
+                profileResult,
+            })
         }
 
         await appendRuntimeReviewSummary(profile, renderOptions)
@@ -154339,35 +154958,160 @@ async function run() {
 }
 
 /**
- * Reads and parses the JSON profile produced by Jibril, or null when the
- * profile is missing or unreadable. Returns both the raw parsed JSON (the
- * Step Summary renders the full-detail report from it, v6.1 §8) and the
- * normalized shape used by the PR-comment state machinery.
+ * Reads and parses the JSON profile produced by Jibril, distinguishing a
+ * missing file from an empty or unparsable one so the control plane can be
+ * told which of them happened.
  * @param {string} jsonProfilerFile
  * @param {boolean} debug
- * @returns {Promise<LoadedProfile | null>}
+ * @returns {Promise<ProfileResult>}
  */
 async function readProfile(jsonProfilerFile, debug) {
     try {
-        const jsonProfile = await readOptionalRootFile(jsonProfilerFile)
-        if (jsonProfile === "") {
-            info(`${JSON_PROFILE_LABEL} not found: ${jsonProfilerFile}`)
-            return null
-        }
+        const stat = await statRootFile(jsonProfilerFile)
+        const jsonProfile = stat.exists ? await readOptionalRootFile(jsonProfilerFile) : ""
 
-        if (debug) {
+        if (debug && jsonProfile !== "") {
             info(`${JSON_PROFILE_LABEL} contents:`)
             info(jsonProfile)
         }
 
-        return {
-            normalized: parseProfileJson(jsonProfile),
-            raw: JSON.parse(jsonProfile),
+        const result = classifyProfileContent(stat, jsonProfile)
+        switch (result.state) {
+            case "missing":
+                info(`${JSON_PROFILE_LABEL} not found: ${jsonProfilerFile}`)
+                break
+            case "empty":
+                info(`${JSON_PROFILE_LABEL} is empty: ${jsonProfilerFile}`)
+                break
+            case "invalid":
+                warning(`failed to parse ${JSON_PROFILE_LABEL}: ${result.detail}`)
+                break
         }
+
+        return result
     } catch (error) {
         warning(`failed to read ${JSON_PROFILE_LABEL}: ${getErrorMessage(error)}`)
-        return null
+        return {
+            state: "invalid",
+            profile: null,
+            detail: getErrorMessage(error),
+        }
     }
+}
+
+/**
+ * Reports to the control plane that this run's sensor stopped without leaving
+ * a usable Run Profile, authenticated as the agent itself. Best-effort: every
+ * failure is logged and swallowed so the job stays green.
+ * @param {AgentStopObservations} observations
+ * @returns {Promise<void>}
+ */
+async function reportAgentStop(observations) {
+    try {
+        const jobStatus = await resolveJobStatus()
+
+        /** @type {AgentStopEvidence} */
+        const evidence = {
+            jobStatus: jobStatus.status,
+            unitStateBeforeStop: observations.unitStateBeforeStop,
+            unitStateAfterStop: observations.unitStateAfterStop,
+            stopOutcome: observations.stopOutcome,
+            forceStopped: observations.forceStopped,
+            stopTimeoutSeconds: observations.stopTimeoutSeconds,
+            profileState: observations.profileResult.state,
+        }
+
+        // The evidence detail already names the profile state; only a parse
+        // failure carries extra information worth forwarding.
+        let parseDetail = ""
+        if (observations.profileResult.state === "invalid") {
+            parseDetail = observations.profileResult.detail
+        }
+
+        const request = buildAgentStoppedRequest(evidence, jobStatus, parseDetail)
+        const client = new ControlPlaneClient({
+            baseURL: resolveControlPlaneBaseURL(),
+            agentToken: observations.agentToken,
+        })
+
+        await client.reportAgentStopped(request)
+        info(`control plane: reported agent stop (reason=${request.reason}, profile=${request.profile_state})`)
+    } catch (error) {
+        info(`control plane: agent stop report skipped: ${getErrorMessage(error)}`)
+    }
+}
+
+/**
+ * Resolves the job's status from the GitHub API (best-effort). The signal is
+ * only used to classify missing-profile runs more accurately.
+ * @returns {Promise<JobStatusResolution>}
+ */
+async function resolveJobStatus() {
+    return resolveJobStatusFromGitHub({
+        token: firstNonEmptyString(getState("githubToken"), shared_getEnv("GITHUB_TOKEN")),
+        repository: shared_getEnv("GITHUB_REPOSITORY"),
+        runID: shared_getEnv("GITHUB_RUN_ID"),
+        runAttempt: shared_getEnv("GITHUB_RUN_ATTEMPT"),
+        runnerName: shared_getEnv("RUNNER_NAME"),
+        jobName: shared_getEnv("GITHUB_JOB"),
+    })
+}
+
+/**
+ * @param {AgentStopEvidence} evidence
+ * @param {JobStatusResolution} jobStatus
+ * @param {string} parseDetail
+ * @returns {AgentStoppedRequest}
+ */
+function buildAgentStoppedRequest(evidence, jobStatus, parseDetail) {
+    /** @type {AgentStoppedJibrilFields} */
+    const jibril = {
+        stop_outcome: evidence.stopOutcome,
+        force_stopped: evidence.forceStopped,
+    }
+
+    const unitState = evidence.unitStateAfterStop
+    if (unitState !== null) {
+        jibril.active_state = unitState.activeState
+        jibril.result = unitState.result
+        jibril.exec_main_status = unitState.execMainStatus
+    }
+
+    /** @type {AgentStoppedRequest} */
+    const request = {
+        reason: classifyAgentStop(evidence),
+        profile_state: evidence.profileState,
+        detail: joinDetails(formatAgentStopDetail(evidence), parseDetail),
+        run_id: shared_getEnv("GITHUB_RUN_ID"),
+        jibril,
+    }
+
+    const runAttempt = shared_getEnv("GITHUB_RUN_ATTEMPT")
+    if (runAttempt !== "") {
+        request.run_attempt = runAttempt
+    }
+
+    const job = getProfileJobName()
+    if (job !== "") {
+        request.job = job
+    }
+
+    // The source is only meaningful alongside a status, and "unknown" is
+    // expressed by omitting both.
+    if (jobStatus.status !== "" && jobStatus.source !== "unknown") {
+        request.job_status = jobStatus.status
+        request.job_status_source = jobStatus.source
+    }
+
+    return request
+}
+
+/**
+ * @param {...string} details
+ * @returns {string}
+ */
+function joinDetails(...details) {
+    return details.filter(detail => detail !== "").join("; ")
 }
 
 /**
@@ -154375,22 +155119,22 @@ async function readProfile(jsonProfilerFile, debug) {
  * the profiles recorded for the agent created in the main step. Fail-closed:
  * any missing credential, missing agent, ambiguity, or request failure
  * returns "" and the render keeps its existing linkless behavior.
+ * @param {string} agentID
  * @returns {Promise<string>}
  */
-async function resolveProfileEnvelopeID() {
-    const agentID = getState("agentID")
+async function resolveProfileEnvelopeID(agentID) {
     if (agentID === "") {
         return ""
     }
 
-    const baseURL = firstNonEmptyString(getEnv("GARNET_API_URL"), getInput("api_url"), "https://api.garnet.ai")
-    const projectToken = firstNonEmptyString(getInput("api_token"), getEnv("GARNET_API_TOKEN"))
+    const baseURL = resolveControlPlaneBaseURL()
+    const projectToken = firstNonEmptyString(getInput("api_token"), shared_getEnv("GARNET_API_TOKEN"))
     const workflowToken = projectToken === "" ? await resolvePostWorkflowToken(baseURL) : ""
     if (projectToken === "" && workflowToken === "") {
         return ""
     }
 
-    const runID = getEnv("GITHUB_RUN_ID")
+    const runID = shared_getEnv("GITHUB_RUN_ID")
     if (runID === "") {
         return ""
     }
@@ -154404,7 +155148,7 @@ async function resolveProfileEnvelopeID() {
 
         const page = await client.agentProfiles(agentID, {
             runID,
-            runAttempt: getEnv("GITHUB_RUN_ATTEMPT"),
+            runAttempt: shared_getEnv("GITHUB_RUN_ATTEMPT"),
         })
 
         // The main step creates one agent per job, so the agent's profile
@@ -154447,6 +155191,13 @@ async function resolvePostWorkflowToken(baseURL) {
 }
 
 /**
+ * @returns {string}
+ */
+function resolveControlPlaneBaseURL() {
+    return firstNonEmptyString(shared_getEnv("GARNET_API_URL"), getInput("api_url"), "https://api.garnet.ai")
+}
+
+/**
  * Render options for this publish flow; the clock is pinned once so every
  * render in the flow produces identical bytes.
  * @returns {RenderOptions}
@@ -154466,7 +155217,7 @@ function getRenderOptions() {
  * @returns {Promise<void>}
  */
 async function appendRuntimeReviewSummary(profile, renderOptions) {
-    const summaryFile = getEnv("GITHUB_STEP_SUMMARY")
+    const summaryFile = shared_getEnv("GITHUB_STEP_SUMMARY")
     if (summaryFile === "") {
         warning("GITHUB_STEP_SUMMARY is not set, cannot write summary")
         return
@@ -154474,8 +155225,8 @@ async function appendRuntimeReviewSummary(profile, renderOptions) {
 
     let content
     if (profile === null) {
-        const sha = getEnv("GITHUB_SHA")
-        const repository = getEnv("GITHUB_REPOSITORY")
+        const sha = shared_getEnv("GITHUB_SHA")
+        const repository = shared_getEnv("GITHUB_REPOSITORY")
         content = renderPendingReview({
             sha,
             commitUrl: repository !== "" && sha !== "" ? `https://github.com/${repository}/commit/${sha}` : "",
@@ -154510,9 +155261,9 @@ function logProfileReportLink(profile) {
 
     if (link === "") {
         link = buildReportLink({
-            repository: getEnv("GITHUB_REPOSITORY"),
-            run_id: getEnv("GITHUB_RUN_ID"),
-            job: getEnv("GITHUB_JOB"),
+            repository: shared_getEnv("GITHUB_REPOSITORY"),
+            run_id: shared_getEnv("GITHUB_RUN_ID"),
+            job: shared_getEnv("GITHUB_JOB"),
         })
     }
 
@@ -154529,19 +155280,19 @@ function logProfileReportLink(profile) {
  * @returns {Promise<void>}
  */
 async function publishProfilerComment(profile, renderOptions) {
-    const eventPath = getEnv("GITHUB_EVENT_PATH")
+    const eventPath = shared_getEnv("GITHUB_EVENT_PATH")
     if (eventPath === "") {
         info("github: GITHUB_EVENT_PATH is not set, skipping PR comment")
         return
     }
 
-    const repository = getEnv("GITHUB_REPOSITORY")
+    const repository = shared_getEnv("GITHUB_REPOSITORY")
     if (repository === "") {
         warning("github: GITHUB_REPOSITORY is not set, skipping PR comment")
         return
     }
 
-    const token = firstNonEmptyString(getState("githubToken"), getEnv("GITHUB_TOKEN"))
+    const token = firstNonEmptyString(getState("githubToken"), shared_getEnv("GITHUB_TOKEN"))
     if (token === "") {
         warning("github: github_token is not set, skipping PR comment")
         return
@@ -154553,7 +155304,7 @@ async function publishProfilerComment(profile, renderOptions) {
         return
     }
 
-    const runAttempt = post_parseRunAttempt(getEnv("GITHUB_RUN_ATTEMPT"))
+    const runAttempt = post_parseRunAttempt(shared_getEnv("GITHUB_RUN_ATTEMPT"))
 
     try {
         const result = await publishPullRequestComment({
@@ -154693,12 +155444,10 @@ async function waitForRootFile(filePath, deadlineMs) {
 }
 
 /**
- * Logs the jibril unit state so runs with a missing or partial profile
- * carry enough context to diagnose (still deactivating, killed on the
- * stop timeout, or exited cleanly).
- * @returns {Promise<void>}
+ * Reads the jibril unit state for diagnostics and stop-reason classification.
+ * @returns {Promise<JibrilUnitState | null>}
  */
-async function logJibrilServiceState() {
+async function readJibrilUnitState() {
     try {
         const result = await getExecOutput(
             "sudo",
@@ -154708,29 +155457,71 @@ async function logJibrilServiceState() {
                 ignoreReturnCode: true,
             },
         )
-        const state = result.stdout.trim().split("\n").join(", ")
-        if (state !== "") {
-            info(`jibril service state: ${state}`)
+        if (result.exitCode !== 0) {
+            return null
+        }
+
+        const properties = parseSystemctlProperties(result.stdout)
+        return {
+            activeState: properties.get("ActiveState") ?? "",
+            result: properties.get("Result") ?? "",
+            execMainStatus: parseExecMainStatus(properties.get("ExecMainStatus")),
         }
     } catch (error) {
         info(`could not read jibril service state: ${getErrorMessage(error)}`)
+        return null
     }
 }
 
 /**
- * Resolves how long the post step waits for `systemctl stop` to complete.
- * An explicit environment override wins; otherwise the unit's own
- * TimeoutStopSec is read live (so the bound tracks the unit instead of a
- * hardcoded copy) plus a grace period, with a fallback when the unit
- * property is unreadable or infinite.
- * @returns {Promise<number>}
+ * @param {string} label
+ * @param {JibrilUnitState | null} state
+ * @returns {void}
  */
-async function resolveStopTimeoutSeconds() {
-    const override = parsePositiveInteger(getEnv(STOP_TIMEOUT_ENV), 0)
-    if (override > 0) {
-        return override
+function logJibrilUnitState(label, state) {
+    if (state === null) {
+        return
     }
 
+    const line = `ActiveState=${state.activeState}, Result=${state.result}, ExecMainStatus=${state.execMainStatus}`
+    info(`${label}: ${line}`)
+}
+
+/**
+ * Resolves how long the post step waits for `systemctl stop` to complete.
+ * @returns {Promise<number>}
+ */
+async function resolvePostStopTimeoutSeconds() {
+    const fromSettings = resolveStopTimeoutFromSettings({
+        envOverride: shared_getEnv(STOP_TIMEOUT_ENV),
+        savedState: getState("stopTimeoutSeconds"),
+    })
+    if (fromSettings !== null) {
+        return fromSettings
+    }
+
+    // Only runs whose saved state predates `stopTimeoutSeconds` pay for this
+    // extra `systemctl` round-trip.
+    return resolveStopTimeoutFromUnit(await readUnitStopTimeoutSeconds())
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+async function forceStopJibril() {
+    warning("force stopping jibril: the shutdown flush did not finish within the configured bound")
+    await exec_exec("sudo", ["systemctl", "kill", "--signal=SIGKILL", "jibril.service"], {
+        ignoreReturnCode: true,
+    })
+    await exec_exec("sudo", ["timeout", "30s", "systemctl", "stop", "jibril.service"], {
+        ignoreReturnCode: true,
+    })
+}
+
+/**
+ * @returns {Promise<number | null>}
+ */
+async function readUnitStopTimeoutSeconds() {
     try {
         const result = await getExecOutput(
             "sudo",
@@ -154740,17 +155531,15 @@ async function resolveStopTimeoutSeconds() {
                 ignoreReturnCode: true,
             },
         )
-        if (result.exitCode === 0) {
-            const unitSeconds = parseSystemdTimespanSeconds(result.stdout.trim())
-            if (unitSeconds !== null) {
-                return unitSeconds + STOP_TIMEOUT_GRACE_SECONDS
-            }
+        if (result.exitCode !== 0) {
+            return null
         }
+
+        return parseSystemdTimespanSeconds(result.stdout.trim())
     } catch (error) {
         info(`could not read jibril unit stop timeout: ${getErrorMessage(error)}`)
+        return null
     }
-
-    return FALLBACK_STOP_TIMEOUT_SECONDS + STOP_TIMEOUT_GRACE_SECONDS
 }
 
 /**
@@ -154764,6 +155553,23 @@ function parsePositiveInteger(value, def) {
         return parsedValue
     }
     return def
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<RootFileStat>}
+ */
+async function statRootFile(filePath) {
+    const result = await getExecOutput("sudo", ["stat", "-c", "%s", filePath], {
+        silent: true,
+        ignoreReturnCode: true,
+    })
+    if (result.exitCode !== 0) {
+        return { exists: false, size: 0 }
+    }
+
+    const size = Number.parseInt(result.stdout.trim(), 10)
+    return { exists: true, size: Number.isSafeInteger(size) && size > 0 ? size : 0 }
 }
 
 /**
@@ -154805,6 +155611,35 @@ async function readRootFileContent(filePath) {
     }
 
     return result.stdout.trim()
+}
+
+/**
+ * Parses the `key=value` lines printed by `systemctl show`.
+ * @param {string} output
+ * @returns {Map<string, string>}
+ */
+function parseSystemctlProperties(output) {
+    /** @type {Map<string, string>} */
+    const properties = new Map()
+
+    for (const line of output.split("\n")) {
+        const separatorIndex = line.indexOf("=")
+        if (separatorIndex === -1) {
+            continue
+        }
+        properties.set(line.slice(0, separatorIndex).trim(), line.slice(separatorIndex + 1).trim())
+    }
+
+    return properties
+}
+
+/**
+ * @param {string | undefined} value
+ * @returns {number}
+ */
+function parseExecMainStatus(value) {
+    const parsedValue = Number.parseInt(value ?? "", 10)
+    return Number.isSafeInteger(parsedValue) ? parsedValue : 0
 }
 
 run()

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -94805,9 +94805,6 @@ class NodeHttpClient {
                 body = uploadReportStream;
             }
             const res = await this.makeRequest(request, abortController, body);
-            if (timeoutId !== undefined) {
-                clearTimeout(timeoutId);
-            }
             const headers = getResponseHeaders(res);
             const status = res.statusCode ?? 0;
             const response = {
@@ -94845,6 +94842,9 @@ class NodeHttpClient {
             return response;
         }
         finally {
+            if (timeoutId !== undefined) {
+                clearTimeout(timeoutId);
+            }
             // clean up event listener
             if (request.abortSignal && abortListener) {
                 let uploadStreamDone = Promise.resolve();
@@ -95418,7 +95418,7 @@ function isSystemError(err) {
 ;// CONCATENATED MODULE: ./node_modules/@typespec/ts-http-runtime/dist/esm/constants.js
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-const constants_SDK_VERSION = "0.3.8";
+const constants_SDK_VERSION = "0.3.9";
 const constants_DEFAULT_RETRY_POLICY_COUNT = 3;
 //# sourceMappingURL=constants.js.map
 ;// CONCATENATED MODULE: ./node_modules/@typespec/ts-http-runtime/dist/esm/policies/retryPolicy.js
@@ -95447,7 +95447,6 @@ function retryPolicy_retryPolicy(strategies, options = { maxRetries: constants_D
             let retryCount = -1;
             retryRequest: while (true) {
                 retryCount += 1;
-                response = undefined;
                 responseError = undefined;
                 try {
                     logger.info(`Retry ${retryCount}: Attempting to send request`, request.requestId);
@@ -100792,7 +100791,7 @@ function serializeRequestBody(request, operationArguments, operationSpec, string
             }
         }
         catch (error) {
-            throw new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(serializedName, undefined, "  ")}.`);
+            throw new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(serializedName, undefined, "  ")}.`, { cause: error });
         }
     }
     else if (operationSpec.formDataParameters && operationSpec.formDataParameters.length > 0) {

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -90883,23 +90883,23 @@ const API_ERROR_SCHEMA = object({
 
 /**
  * @typedef {object} AgentStoppedJibrilFields
- * @property {string=} active_state
+ * @property {string=} activeState
  * @property {string=} result
- * @property {number=} exec_main_status
- * @property {AgentStopOutcome=} stop_outcome
- * @property {boolean=} force_stopped
+ * @property {number=} execMainStatus
+ * @property {AgentStopOutcome=} stopOutcome
+ * @property {boolean=} forceStopped
  */
 
 /**
  * @typedef {object} AgentStoppedRequest
  * @property {AgentStopReason} reason
- * @property {AgentProfileState} profile_state
+ * @property {AgentProfileState} profileState
  * @property {string=} detail
- * @property {string} run_id
- * @property {string=} run_attempt
+ * @property {string} runID
+ * @property {string=} runAttempt
  * @property {string=} job
- * @property {string=} job_status
- * @property {JobStatusSource=} job_status_source
+ * @property {"cancelled" | "failure"=} jobStatus
+ * @property {JobStatusSource=} jobStatusSource
  * @property {AgentStoppedJibrilFields=} jibril
  */
 
@@ -90919,19 +90919,19 @@ const AGENT_STOP_REASON_SCHEMA = schemas_enum(["run_cancelled", "crashed", "flus
 
 const AGENT_STOPPED_REQUEST_SCHEMA = object({
     reason: AGENT_STOP_REASON_SCHEMA,
-    profile_state: schemas_enum(["present", "missing", "empty", "invalid"]),
+    profileState: schemas_enum(["present", "missing", "empty", "invalid"]),
     detail: schemas_string().optional(),
-    run_id: schemas_string().min(1),
-    run_attempt: schemas_string().min(1).optional(),
+    runID: schemas_string().min(1),
+    runAttempt: schemas_string().min(1).optional(),
     job: schemas_string().min(1).optional(),
-    job_status: schemas_string().min(1).optional(),
-    job_status_source: schemas_enum(["github_api"]).optional(),
+    jobStatus: schemas_enum(["cancelled", "failure"]).optional(),
+    jobStatusSource: schemas_enum(["github_api"]).optional(),
     jibril: object({
-            active_state: schemas_string().optional(),
+            activeState: schemas_string().optional(),
             result: schemas_string().optional(),
-            exec_main_status: schemas_number().int().optional(),
-            stop_outcome: schemas_enum(["completed", "timed_out"]).optional(),
-            force_stopped: schemas_boolean().optional(),
+            execMainStatus: schemas_number().int().optional(),
+            stopOutcome: schemas_enum(["completed", "timed_out"]).optional(),
+            forceStopped: schemas_boolean().optional(),
         })
         .optional(),
 })
@@ -155034,7 +155034,7 @@ async function reportAgentStop(observations) {
         })
 
         await client.reportAgentStopped(request)
-        info(`control plane: reported agent stop (reason=${request.reason}, profile=${request.profile_state})`)
+        info(`control plane: reported agent stop (reason=${request.reason}, profile=${request.profileState})`)
     } catch (error) {
         info(`control plane: agent stop report skipped: ${getErrorMessage(error)}`)
     }
@@ -155065,29 +155065,29 @@ async function resolveJobStatus() {
 function buildAgentStoppedRequest(evidence, jobStatus, parseDetail) {
     /** @type {AgentStoppedJibrilFields} */
     const jibril = {
-        stop_outcome: evidence.stopOutcome,
-        force_stopped: evidence.forceStopped,
+        stopOutcome: evidence.stopOutcome,
+        forceStopped: evidence.forceStopped,
     }
 
     const unitState = evidence.unitStateAfterStop
     if (unitState !== null) {
-        jibril.active_state = unitState.activeState
+        jibril.activeState = unitState.activeState
         jibril.result = unitState.result
-        jibril.exec_main_status = unitState.execMainStatus
+        jibril.execMainStatus = unitState.execMainStatus
     }
 
     /** @type {AgentStoppedRequest} */
     const request = {
         reason: classifyAgentStop(evidence),
-        profile_state: evidence.profileState,
+        profileState: evidence.profileState,
         detail: joinDetails(formatAgentStopDetail(evidence), parseDetail),
-        run_id: shared_getEnv("GITHUB_RUN_ID"),
+        runID: shared_getEnv("GITHUB_RUN_ID"),
         jibril,
     }
 
     const runAttempt = shared_getEnv("GITHUB_RUN_ATTEMPT")
     if (runAttempt !== "") {
-        request.run_attempt = runAttempt
+        request.runAttempt = runAttempt
     }
 
     const job = getProfileJobName()
@@ -155097,9 +155097,10 @@ function buildAgentStoppedRequest(evidence, jobStatus, parseDetail) {
 
     // The source is only meaningful alongside a status, and "unknown" is
     // expressed by omitting both.
-    if (jobStatus.status !== "" && jobStatus.source !== "unknown") {
-        request.job_status = jobStatus.status
-        request.job_status_source = jobStatus.source
+    const status = toAgentStoppedJobStatus(jobStatus.status)
+    if (status !== "" && jobStatus.source !== "unknown") {
+        request.jobStatus = status
+        request.jobStatusSource = jobStatus.source
     }
 
     return request
@@ -155111,6 +155112,17 @@ function buildAgentStoppedRequest(evidence, jobStatus, parseDetail) {
  */
 function joinDetails(...details) {
     return details.filter(detail => detail !== "").join("; ")
+}
+
+/**
+ * @param {string} value
+ * @returns {"cancelled" | "failure" | ""}
+ */
+function toAgentStoppedJobStatus(value) {
+    if (value === "cancelled" || value === "failure") {
+        return value
+    }
+    return ""
 }
 
 /**

--- a/dist/post/licenses.txt
+++ b/dist/post/licenses.txt
@@ -134,29 +134,6 @@ SOFTWARE.
 
 
 @azure/core-client
-MIT
-Copyright (c) Microsoft Corporation.
-
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 
 @azure/core-http-compat
 MIT
@@ -950,29 +927,6 @@ Apache-2.0
 
 
 @typespec/ts-http-runtime
-MIT
-Copyright (c) Microsoft Corporation.
-
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 
 @vercel/ncc
 MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "zod": "^4.5.4"
             },
             "devDependencies": {
-                "@types/node": "^26.4.0",
+                "@types/node": "^26.4.1",
                 "@vercel/ncc": "^0.45.0",
                 "typescript": "^7.0.2"
             },
@@ -133,9 +133,9 @@
             }
         },
         "node_modules/@azure/core-client": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.11.0.tgz",
-            "integrity": "sha512-JjQWO6akOck45PH/XBrxzsQGAiKrfFl4m5iggJ0ItMIz5omRufOXWpqCPpdjKN3vKDzlSUvFjaMb7Zwf0gvAdA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.11.1.tgz",
+            "integrity": "sha512-2QygG2F76ZpMP2eMztiJvAiFMu71M9rDeU7vO/QKg5Css7MgM4frUOslFjhVjRhbGaCNPtz/S8M6y46/fFKVuQ==",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.1.2",
@@ -635,9 +635,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "26.4.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
-            "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+            "version": "26.4.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+            "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -977,9 +977,9 @@
             }
         },
         "node_modules/@typespec/ts-http-runtime": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz",
-            "integrity": "sha512-bLMpVcWZNzq6lYOybwFwOAR1IXKcHnhUNqYeHjl1bET/qE3jFPFH+p8Wrh3rU4xwdnifPxmKNESBYnvnmc75aA==",
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.9.tgz",
+            "integrity": "sha512-edSdeAqkdxBVzA1yL1LrLCml1YjyCVvPMtMqJpbF+6K609tHe8V6sQUzFQSGcYNhcuhOceZtjvN32+mpIth30A==",
             "license": "MIT",
             "dependencies": {
                 "http-proxy-agent": "^7.0.0",
@@ -1158,9 +1158,9 @@
             }
         },
         "node_modules/bare-path": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
-            "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.2.tgz",
+            "integrity": "sha512-ZyKbsuuqK6Ag0K8pX6V5Txq6XeJRvY+wXucnFGRjiyVYP9YWDpIQugk/b+enRYrEYBJaqLzghRQpXPMR7341Nw==",
             "license": "Apache-2.0"
         },
         "node_modules/bare-stream": {
@@ -1191,9 +1191,9 @@
             }
         },
         "node_modules/bare-url": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.2.tgz",
-            "integrity": "sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.4.tgz",
+            "integrity": "sha512-Gxa7UVWBr0/edU1b+TJhn/AZvMQUj9OGspvYsaTYQrAbZA4BOTZGL3LiZxvD+CeMlDH4juwD84+eTAp/bLYW5g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "bare-path": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "zod": "^4.5.4"
     },
     "devDependencies": {
-        "@types/node": "^26.4.0",
+        "@types/node": "^26.4.1",
         "@vercel/ncc": "^0.45.0",
         "typescript": "^7.0.2"
     },

--- a/src/action.js
+++ b/src/action.js
@@ -218,6 +218,9 @@ export async function run() {
         // The post step resolves the run's profile envelope ID from this agent.
         core.saveState("agentID", AGENT_ID)
 
+        // The post step authenticates as this agent to report stop reasons.
+        core.saveState("agentToken", AGENT_TOKEN)
+
         // Get network policy
         core.info("Getting network policy")
 
@@ -341,11 +344,15 @@ StandardOutput=append:/var/log/jibril.log
         await execSudo(["cp", loggingConfPath, "/etc/systemd/system/jibril.service.d/logging.conf"])
 
         // Raise the unit's stop ceiling so the shutdown event flush can
-        // complete and the JSON profile gets written on heavy jobs.
+        // complete and the JSON profile gets written on heavy jobs. A
+        // disabled bound is written as `infinity` rather than `0`: systemd
+        // only reads `0` as "no timeout" through a legacy compatibility
+        // path, and `0s` meant an immediate SIGKILL on some versions.
         const stopTimeoutSeconds = resolveStopTimeoutSeconds(getEnv(JIBRIL_STOP_TIMEOUT_ENV, ""))
-        core.info(`Configuring Jibril stop timeout (${stopTimeoutSeconds}s)`)
+        const stopTimeoutValue = stopTimeoutSeconds > 0 ? String(stopTimeoutSeconds) : "infinity"
+        core.info(`Configuring Jibril stop timeout (${stopTimeoutValue})`)
         const stopTimeoutConf = `[Service]
-TimeoutStopSec=${stopTimeoutSeconds}
+TimeoutStopSec=${stopTimeoutValue}
 `
         const stopTimeoutConfPath = path.join(tmpDir, "stop-timeout.conf")
         await fs.writeFile(stopTimeoutConfPath, stopTimeoutConf)
@@ -923,19 +930,23 @@ function parseReleaseManifest(manifestText) {
 
 /**
  * Resolves the stop ceiling written into the unit's drop-in. An explicit
- * positive-integer environment override wins; otherwise the default is used.
+ * integer wins, where zero or negative means "no bound at all"; anything
+ * unset or unparsable falls back to the default.
  * @param {string} overrideValue
- * @returns {number}
+ * @returns {number} seconds, or 0 when the bound is disabled
  */
 export function resolveStopTimeoutSeconds(overrideValue) {
     const text = String(overrideValue === undefined || overrideValue === null ? "" : overrideValue).trim()
-    if (text !== "" && /^\d+$/.test(text)) {
-        const parsed = Number.parseInt(text, 10)
-        if (Number.isSafeInteger(parsed) && parsed > 0) {
-            return parsed
-        }
+    if (!/^-?\d+$/.test(text)) {
+        return DEFAULT_JIBRIL_STOP_TIMEOUT_SECONDS
     }
-    return DEFAULT_JIBRIL_STOP_TIMEOUT_SECONDS
+
+    const parsed = Number.parseInt(text, 10)
+    if (!Number.isSafeInteger(parsed)) {
+        return DEFAULT_JIBRIL_STOP_TIMEOUT_SECONDS
+    }
+
+    return parsed > 0 ? parsed : 0
 }
 
 /**

--- a/src/control-plane/client.js
+++ b/src/control-plane/client.js
@@ -1,5 +1,6 @@
 import {
     AGENT_CREATED_RESPONSE_SCHEMA,
+    AGENT_STOPPED_REQUEST_SCHEMA,
     API_ERROR_SCHEMA,
     CREATE_AGENT_REQUEST_SCHEMA,
     EXCHANGE_OIDC_REQUEST_SCHEMA,
@@ -14,6 +15,7 @@ import {
  * @typedef {import("./types.js").MergedNetPoliciesRequest} MergedNetPoliciesRequest
  * @typedef {import("./types.js").ExchangeOIDCResponse} ExchangeOIDCResponse
  * @typedef {import("./types.js").ProfileEnvelopePage} ProfileEnvelopePage
+ * @typedef {import("./types.js").AgentStoppedRequest} AgentStoppedRequest
  */
 
 /**
@@ -28,6 +30,7 @@ import {
  *   baseURL: string
  *   projectToken?: string
  *   workflowToken?: string
+ *   agentToken?: string
  *   userAgent?: string
  * }} ControlPlaneClientOptions
  */
@@ -40,6 +43,7 @@ import {
  *   body?: unknown
  *   accept?: string
  *   skipAuthHeader?: boolean
+ *   timeoutMs?: number
  * }} RequestOptions
  */
 
@@ -90,9 +94,14 @@ export class ControlPlaneClient {
             throw new Error("ControlPlaneClient: 'workflowToken' must be a string when provided")
         }
 
+        if (options.agentToken !== undefined && typeof options.agentToken !== "string") {
+            throw new Error("ControlPlaneClient: 'agentToken' must be a string when provided")
+        }
+
         this.baseURL = parsedBaseURL.toString().replace(/\/+$/, "")
         this.projectToken = options.projectToken?.trim() ?? ""
         this.workflowToken = options.workflowToken?.trim() ?? ""
+        this.agentToken = options.agentToken?.trim() ?? ""
         this.userAgent = options.userAgent ?? "garnet-action"
     }
 
@@ -157,6 +166,24 @@ export class ControlPlaneClient {
         })
 
         return PROFILE_ENVELOPE_PAGE_SCHEMA.parse(responseJson)
+    }
+
+    /**
+     * Signals that this run's sensor stopped, with the reason and whether a usable
+     * Run Profile was produced, so the control plane can resolve pending state.
+     * Authenticated as the agent itself.
+     * @param {AgentStoppedRequest} input
+     * @returns {Promise<void>}
+     */
+    async reportAgentStopped(input) {
+        const payload = AGENT_STOPPED_REQUEST_SCHEMA.parse(input)
+        // Keep the post step fast: one bounded best-effort request only.
+        await this.requestText({
+            method: "POST",
+            path: "/api/v1/agent/stopped",
+            body: payload,
+            timeoutMs: 10_000,
+        })
     }
 
     /**
@@ -232,7 +259,9 @@ export class ControlPlaneClient {
         }
 
         if (options.skipAuthHeader !== true) {
-            if (this.workflowToken !== "") {
+            if (this.agentToken !== "") {
+                headers["X-Agent-Token"] = this.agentToken
+            } else if (this.workflowToken !== "") {
                 headers["X-Workflow-Token"] = this.workflowToken
             } else if (this.projectToken !== "") {
                 headers["X-Project-Token"] = this.projectToken
@@ -243,38 +272,39 @@ export class ControlPlaneClient {
             headers["Content-Type"] = "application/json"
         }
 
+        /** @type {RequestInit} */
+        const requestInit = {
+            method: options.method,
+            headers,
+        }
+
+        if (options.body !== undefined) {
+            requestInit.body = JSON.stringify(options.body)
+        }
+
+        if (options.timeoutMs !== undefined) {
+            requestInit.signal = AbortSignal.timeout(options.timeoutMs)
+        }
+
         let response
         try {
-            if (options.body === undefined) {
-                response = await fetch(requestURL, {
-                    method: options.method,
-                    headers,
-                })
-            } else {
-                response = await fetch(requestURL, {
-                    method: options.method,
-                    headers,
-                    body: JSON.stringify(options.body),
-                })
-            }
+            response = await fetch(requestURL, requestInit)
         } catch (error) {
             const reason = error instanceof Error ? error.message : String(error)
-            throw new Error(
-                `Control plane request failed: ${options.method} ${options.path} (network error: ${reason})`,
-            )
+            throw new Error(`Control plane request failed: ${options.method} ${options.path} (network error: ${reason})`)
         }
 
         const responseText = await response.text()
-        if (!response.ok) {
-            const detail = getApiErrorDetail(responseText)
-            const statusDetail = detail === "" ? `HTTP ${response.status}` : `HTTP ${response.status}: ${detail}`
-            throw new Error(`Control plane request failed: ${options.method} ${options.path} (${statusDetail})`)
+        if (response.ok) {
+            return {
+                status: response.status,
+                responseText,
+            }
         }
 
-        return {
-            status: response.status,
-            responseText,
-        }
+        const detail = getApiErrorDetail(responseText)
+        const statusDetail = detail === "" ? `HTTP ${response.status}` : `HTTP ${response.status}: ${detail}`
+        throw new Error(`Control plane request failed: ${options.method} ${options.path} (${statusDetail})`)
     }
 }
 

--- a/src/control-plane/types.js
+++ b/src/control-plane/types.js
@@ -164,6 +164,44 @@ export const API_ERROR_SCHEMA = z.object({
  * @property {ProfileEnvelope[]} items
  */
 
+/**
+ * @typedef {"run_cancelled" | "crashed" | "flush_timeout" | "stopped_cleanly"} AgentStopReason
+ */
+
+/**
+ * @typedef {"present" | "missing" | "empty" | "invalid"} AgentProfileState
+ */
+
+/**
+ * @typedef {"completed" | "timed_out"} AgentStopOutcome
+ */
+
+/**
+ * @typedef {"github_api"} JobStatusSource
+ */
+
+/**
+ * @typedef {object} AgentStoppedJibrilFields
+ * @property {string=} active_state
+ * @property {string=} result
+ * @property {number=} exec_main_status
+ * @property {AgentStopOutcome=} stop_outcome
+ * @property {boolean=} force_stopped
+ */
+
+/**
+ * @typedef {object} AgentStoppedRequest
+ * @property {AgentStopReason} reason
+ * @property {AgentProfileState} profile_state
+ * @property {string=} detail
+ * @property {string} run_id
+ * @property {string=} run_attempt
+ * @property {string=} job
+ * @property {string=} job_status
+ * @property {JobStatusSource=} job_status_source
+ * @property {AgentStoppedJibrilFields=} jibril
+ */
+
 export const PROFILE_ENVELOPE_SCHEMA = z
     .object({
         id: z.string().min(1),
@@ -177,3 +215,25 @@ export const PROFILE_ENVELOPE_PAGE_SCHEMA = z
         items: z.array(PROFILE_ENVELOPE_SCHEMA).default([]),
     })
     .passthrough()
+
+export const AGENT_STOP_REASON_SCHEMA = z.enum(["run_cancelled", "crashed", "flush_timeout", "stopped_cleanly"])
+
+export const AGENT_STOPPED_REQUEST_SCHEMA = z.object({
+    reason: AGENT_STOP_REASON_SCHEMA,
+    profile_state: z.enum(["present", "missing", "empty", "invalid"]),
+    detail: z.string().optional(),
+    run_id: z.string().min(1),
+    run_attempt: z.string().min(1).optional(),
+    job: z.string().min(1).optional(),
+    job_status: z.string().min(1).optional(),
+    job_status_source: z.enum(["github_api"]).optional(),
+    jibril: z
+        .object({
+            active_state: z.string().optional(),
+            result: z.string().optional(),
+            exec_main_status: z.number().int().optional(),
+            stop_outcome: z.enum(["completed", "timed_out"]).optional(),
+            force_stopped: z.boolean().optional(),
+        })
+        .optional(),
+})

--- a/src/control-plane/types.js
+++ b/src/control-plane/types.js
@@ -182,23 +182,23 @@ export const API_ERROR_SCHEMA = z.object({
 
 /**
  * @typedef {object} AgentStoppedJibrilFields
- * @property {string=} active_state
+ * @property {string=} activeState
  * @property {string=} result
- * @property {number=} exec_main_status
- * @property {AgentStopOutcome=} stop_outcome
- * @property {boolean=} force_stopped
+ * @property {number=} execMainStatus
+ * @property {AgentStopOutcome=} stopOutcome
+ * @property {boolean=} forceStopped
  */
 
 /**
  * @typedef {object} AgentStoppedRequest
  * @property {AgentStopReason} reason
- * @property {AgentProfileState} profile_state
+ * @property {AgentProfileState} profileState
  * @property {string=} detail
- * @property {string} run_id
- * @property {string=} run_attempt
+ * @property {string} runID
+ * @property {string=} runAttempt
  * @property {string=} job
- * @property {string=} job_status
- * @property {JobStatusSource=} job_status_source
+ * @property {"cancelled" | "failure"=} jobStatus
+ * @property {JobStatusSource=} jobStatusSource
  * @property {AgentStoppedJibrilFields=} jibril
  */
 
@@ -220,20 +220,20 @@ export const AGENT_STOP_REASON_SCHEMA = z.enum(["run_cancelled", "crashed", "flu
 
 export const AGENT_STOPPED_REQUEST_SCHEMA = z.object({
     reason: AGENT_STOP_REASON_SCHEMA,
-    profile_state: z.enum(["present", "missing", "empty", "invalid"]),
+    profileState: z.enum(["present", "missing", "empty", "invalid"]),
     detail: z.string().optional(),
-    run_id: z.string().min(1),
-    run_attempt: z.string().min(1).optional(),
+    runID: z.string().min(1),
+    runAttempt: z.string().min(1).optional(),
     job: z.string().min(1).optional(),
-    job_status: z.string().min(1).optional(),
-    job_status_source: z.enum(["github_api"]).optional(),
+    jobStatus: z.enum(["cancelled", "failure"]).optional(),
+    jobStatusSource: z.enum(["github_api"]).optional(),
     jibril: z
         .object({
-            active_state: z.string().optional(),
+            activeState: z.string().optional(),
             result: z.string().optional(),
-            exec_main_status: z.number().int().optional(),
-            stop_outcome: z.enum(["completed", "timed_out"]).optional(),
-            force_stopped: z.boolean().optional(),
+            execMainStatus: z.number().int().optional(),
+            stopOutcome: z.enum(["completed", "timed_out"]).optional(),
+            forceStopped: z.boolean().optional(),
         })
         .optional(),
 })

--- a/src/github-job-status.js
+++ b/src/github-job-status.js
@@ -1,0 +1,164 @@
+import * as core from "@actions/core"
+import * as github from "@actions/github"
+import { getErrorMessage } from "./shared.js"
+
+/**
+ * @typedef {object} JobStatusResolution
+ * @property {string} status
+ * @property {"github_api" | "unknown"} source
+ */
+
+/**
+ * @typedef {object} JobStatusLookup
+ * @property {string} token
+ * @property {string} repository
+ * @property {string} runID
+ * @property {string} runAttempt
+ * @property {string} runnerName
+ * @property {string} jobName
+ */
+
+/**
+ * @typedef {object} WorkflowRunJobStep
+ * @property {string | null=} conclusion
+ */
+
+/**
+ * @typedef {object} WorkflowRunJob
+ * @property {string | null=} name
+ * @property {string | null=} runner_name
+ * @property {string=} status
+ * @property {string | null=} conclusion
+ * @property {WorkflowRunJobStep[]=} steps
+ */
+
+/**
+ * Best-effort: resolves the current job's status from the workflow run's job
+ * list. Fail-closed — any missing permission, ambiguity, or request failure
+ * resolves to an empty status.
+ * @param {JobStatusLookup} lookup
+ * @returns {Promise<JobStatusResolution>}
+ */
+export async function resolveJobStatusFromGitHub(lookup) {
+    const token = lookup.token.trim()
+    const repository = lookup.repository.trim()
+    const runID = lookup.runID.trim()
+    const runAttempt = lookup.runAttempt.trim()
+
+    if (token === "" || repository === "" || runID === "" || runAttempt === "") {
+        return { status: "", source: "unknown" }
+    }
+
+    const [owner = "", repo = ""] = repository.split("/")
+    if (owner === "" || repo === "") {
+        return { status: "", source: "unknown" }
+    }
+
+    const attemptNumber = Number.parseInt(runAttempt, 10)
+    if (!Number.isSafeInteger(attemptNumber) || attemptNumber <= 0) {
+        return { status: "", source: "unknown" }
+    }
+
+    const numericRunID = Number.parseInt(runID, 10)
+    if (!Number.isSafeInteger(numericRunID) || numericRunID <= 0) {
+        return { status: "", source: "unknown" }
+    }
+
+    try {
+        const octokit = github.getOctokit(token)
+        const response = await octokit.rest.actions.listJobsForWorkflowRunAttempt({
+            owner,
+            repo,
+            run_id: numericRunID,
+            attempt_number: attemptNumber,
+            per_page: 100,
+            request: {
+                signal: AbortSignal.timeout(5000),
+            },
+        })
+
+        const jobs = response.data.jobs
+        const status = deriveJobStatusFromJobs(jobs, {
+            runnerName: lookup.runnerName,
+            jobName: lookup.jobName,
+        })
+        if (status === "") {
+            return { status: "", source: "unknown" }
+        }
+
+        return { status, source: "github_api" }
+    } catch (error) {
+        const statusCode = getStatusCode(error)
+        if (statusCode === 403 || statusCode === 404) {
+            core.info(`job-status GitHub API probe skipped: HTTP ${statusCode}`)
+            return { status: "", source: "unknown" }
+        }
+
+        core.info(`job-status GitHub API probe skipped: ${getErrorMessage(error)}`)
+        return { status: "", source: "unknown" }
+    }
+}
+
+/**
+ * @param {WorkflowRunJob[]} jobs
+ * @param {{ runnerName: string, jobName: string }} selector
+ * @returns {string}
+ */
+export function deriveJobStatusFromJobs(jobs, selector) {
+    const runnerMatches = jobs.filter(job => job.runner_name === selector.runnerName && job.status === "in_progress")
+
+    if (runnerMatches.length === 1) {
+        const match = runnerMatches[0]
+        if (match !== undefined) {
+            return deriveJobStatusFromJob(match)
+        }
+    }
+
+    const nameMatches = jobs.filter(job => job.name === selector.jobName)
+    if (nameMatches.length === 1) {
+        const match = nameMatches[0]
+        if (match !== undefined) {
+            return deriveJobStatusFromJob(match)
+        }
+    }
+
+    return ""
+}
+
+/**
+ * @param {WorkflowRunJob} job
+ * @returns {string}
+ */
+function deriveJobStatusFromJob(job) {
+    if (job.conclusion === "cancelled") {
+        return "cancelled"
+    }
+
+    const steps = Array.isArray(job.steps) ? job.steps : []
+    for (const step of steps) {
+        if (step.conclusion === "cancelled") {
+            return "cancelled"
+        }
+    }
+
+    for (const step of steps) {
+        if (step.conclusion === "failure") {
+            return "failure"
+        }
+    }
+
+    return ""
+}
+
+/**
+ * @param {unknown} error
+ * @returns {number}
+ */
+function getStatusCode(error) {
+    if (typeof error !== "object" || error === null) {
+        return 0
+    }
+
+    const maybeError = /** @type {{ status?: unknown }} */ (error)
+    return typeof maybeError.status === "number" ? maybeError.status : 0
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,8 @@
 import * as core from "@actions/core"
 import * as os from "node:os"
-import { run } from "./action.js"
+import { resolveStopTimeoutSeconds, run } from "./action.js"
 import { buildReportLink } from "./profile-comment.js"
-import { getEnv, isSupportedArch, isSupportedPlatform } from "./shared.js"
+import { firstNonEmptyString, getEnv, isSupportedArch, isSupportedPlatform } from "./shared.js"
 
 // This is the main entry point for the action. It is called by the GitHub Actions
 // runtime. The action installs the Jibril security scanner and sets it up as a
@@ -48,6 +48,16 @@ async function main() {
         process.env.GARNET_API_URL = core.getInput("api_url")
         process.env.JIBRIL_VERSION = core.getInput("jibril_version")
         process.env.DEBUG = core.getInput("debug")
+
+        // Resolve the shutdown flush bound once, here at the boundary: the
+        // main step writes it into the unit and the post step reuses the exact
+        // same number from state instead of re-deriving it. Zero means the
+        // bound is disabled.
+        const stopTimeoutSeconds = resolveStopTimeoutSeconds(
+            firstNonEmptyString(core.getInput("stop_timeout_seconds"), getEnv("GARNET_JIBRIL_STOP_TIMEOUT_SECONDS")),
+        )
+        process.env.GARNET_JIBRIL_STOP_TIMEOUT_SECONDS = String(stopTimeoutSeconds)
+        core.saveState("stopTimeoutSeconds", String(stopTimeoutSeconds))
 
         // The Run Profile permalink derives from the run id and the configured
         // API host, so it is known up front — emit the declared report_url output

--- a/src/post-profile-state.js
+++ b/src/post-profile-state.js
@@ -1,0 +1,78 @@
+import { parseProfileJson } from "./profile-comment.js"
+import { getErrorMessage } from "./shared.js"
+
+/** @typedef {import("./profile-comment.js").NormalizedProfile} NormalizedProfile */
+
+/**
+ * @typedef {object} RootFileStat
+ * @property {boolean} exists
+ * @property {number} size
+ */
+
+/**
+ * @typedef {object} LoadedProfile
+ * @property {NormalizedProfile} normalized
+ * @property {unknown} raw
+ */
+
+/**
+ * @typedef {"present" | "missing" | "empty" | "invalid"} ProfileState
+ */
+
+/**
+ * @typedef {object} ProfileResult
+ * @property {ProfileState} state
+ * @property {LoadedProfile | null} profile
+ * @property {string} detail
+ */
+
+/**
+ * @param {RootFileStat} stat
+ * @param {string} content
+ * @returns {ProfileResult}
+ */
+export function classifyProfileContent(stat, content) {
+    if (!stat.exists) {
+        return {
+            state: "missing",
+            profile: null,
+            detail: "profile file missing",
+        }
+    }
+
+    if (stat.size === 0) {
+        return {
+            state: "empty",
+            profile: null,
+            detail: "profile file empty",
+        }
+    }
+
+    if (content.trim() === "") {
+        return {
+            state: "empty",
+            profile: null,
+            detail: "profile file empty",
+        }
+    }
+
+    try {
+        const normalized = parseProfileJson(content)
+        const raw = JSON.parse(content)
+
+        return {
+            state: "present",
+            profile: {
+                normalized,
+                raw,
+            },
+            detail: "",
+        }
+    } catch (error) {
+        return {
+            state: "invalid",
+            profile: null,
+            detail: getErrorMessage(error),
+        }
+    }
+}

--- a/src/post-signal.js
+++ b/src/post-signal.js
@@ -1,0 +1,90 @@
+/** @typedef {import("./post-profile-state.js").ProfileState} ProfileState */
+
+/**
+ * @typedef {object} JibrilUnitState
+ * @property {string} activeState
+ * @property {string} result
+ * @property {number} execMainStatus
+ */
+
+/**
+ * @typedef {object} AgentStopEvidence
+ * @property {string} jobStatus
+ * @property {JibrilUnitState | null} unitStateBeforeStop
+ * @property {JibrilUnitState | null} unitStateAfterStop
+ * @property {"completed" | "timed_out"} stopOutcome
+ * @property {boolean} forceStopped
+ * @property {number} stopTimeoutSeconds
+ * @property {ProfileState} profileState
+ */
+
+/**
+ * @typedef {"run_cancelled" | "crashed" | "flush_timeout" | "stopped_cleanly"} AgentStopReason
+ */
+
+/**
+ * @param {AgentStopEvidence} evidence
+ * @returns {AgentStopReason}
+ */
+export function classifyAgentStop(evidence) {
+    const status = evidence.jobStatus.trim().toLowerCase()
+    if (status === "cancelled" || status === "canceled") {
+        return "run_cancelled"
+    }
+
+    const before = evidence.unitStateBeforeStop
+    if (before !== null) {
+        const hasFailureState = before.activeState === "failed"
+        const hasInactiveFailure = before.activeState === "inactive" && before.result !== "success"
+        const hasNonZeroStatus = before.execMainStatus !== 0
+        if (hasFailureState || hasInactiveFailure || hasNonZeroStatus) {
+            return "crashed"
+        }
+    }
+
+    if (evidence.stopOutcome === "timed_out") {
+        return "flush_timeout"
+    }
+
+    return "stopped_cleanly"
+}
+
+/**
+ * @param {AgentStopEvidence} evidence
+ * @returns {string}
+ */
+export function formatAgentStopDetail(evidence) {
+    /** @type {string[]} */
+    const parts = []
+
+    if (evidence.stopOutcome === "timed_out") {
+        parts.push(`stop timed out after ${evidence.stopTimeoutSeconds}s`)
+    } else {
+        parts.push("stop completed")
+    }
+
+    if (evidence.forceStopped) {
+        parts.push("unit SIGKILLed")
+    }
+
+    parts.push(getProfileStateDetail(evidence.profileState))
+
+    return parts.join("; ")
+}
+
+/**
+ * @param {ProfileState} profileState
+ * @returns {string}
+ */
+function getProfileStateDetail(profileState) {
+    if (profileState === "missing") {
+        return "profile file missing"
+    }
+    if (profileState === "empty") {
+        return "profile file empty"
+    }
+    if (profileState === "invalid") {
+        return "profile JSON invalid"
+    }
+    return "profile present"
+}

--- a/src/post-stop-timeout.js
+++ b/src/post-stop-timeout.js
@@ -1,0 +1,58 @@
+// Resolution of the post step's `systemctl stop` bound. Zero means the bound
+// is disabled and the post step waits for the flush without a ceiling.
+
+const FALLBACK_STOP_TIMEOUT_SECONDS = 1800
+const STOP_TIMEOUT_GRACE_SECONDS = 30
+
+/**
+ * @typedef {object} StopTimeoutSettings
+ * @property {string} envOverride
+ * @property {string} savedState
+ */
+
+/**
+ * Resolves the bound from the values the action itself controls: the env
+ * escape hatch (used verbatim) then the ceiling the main step saved. Returns
+ * null when neither is set, so the caller knows it still has to ask the unit.
+ * @param {StopTimeoutSettings} settings
+ * @returns {number | null} seconds, 0 when disabled, null when unresolved
+ */
+export function resolveStopTimeoutFromSettings(settings) {
+    const envOverride = parseTimeoutSetting(settings.envOverride)
+    if (envOverride !== null) {
+        return envOverride > 0 ? envOverride : 0
+    }
+
+    const savedState = parseTimeoutSetting(settings.savedState)
+    if (savedState !== null) {
+        return savedState > 0 ? savedState + STOP_TIMEOUT_GRACE_SECONDS : 0
+    }
+
+    return null
+}
+
+/**
+ * Resolves the bound for runs whose saved state predates `stopTimeoutSeconds`,
+ * from the unit's own TimeoutStopSec. An unreadable or infinite unit value
+ * keeps the historical fallback rather than removing the ceiling entirely.
+ * @param {number | null} unitTimeoutSeconds
+ * @returns {number} seconds
+ */
+export function resolveStopTimeoutFromUnit(unitTimeoutSeconds) {
+    const seconds = unitTimeoutSeconds === null ? FALLBACK_STOP_TIMEOUT_SECONDS : unitTimeoutSeconds
+    return seconds + STOP_TIMEOUT_GRACE_SECONDS
+}
+
+/**
+ * @param {string} value
+ * @returns {number | null}
+ */
+function parseTimeoutSetting(value) {
+    const text = value.trim()
+    if (!/^-?\d+$/.test(text)) {
+        return null
+    }
+
+    const parsedValue = Number.parseInt(text, 10)
+    return Number.isSafeInteger(parsedValue) ? parsedValue : null
+}

--- a/src/post.js
+++ b/src/post.js
@@ -15,20 +15,42 @@ import {
     waitForDelay,
 } from "./shared.js"
 import { getPullRequestNumberFromEvent } from "./github-event.js"
+import { getProfileJobName } from "./github-context.js"
 import { ControlPlaneClient } from "./control-plane/client.js"
 import { uploadJibrilArtifacts } from "./post-artifacts.js"
-import { buildReportLink, getDefaultJsonProfileFile, parseProfileJson, resolveAppBaseURL } from "./profile-comment.js"
+import { buildReportLink, getDefaultJsonProfileFile, resolveAppBaseURL } from "./profile-comment.js"
 import { profilePermalink, renderPendingReview, renderStepSummary, summarizeProfile } from "./runtime-review.js"
 import { publishPullRequestComment } from "./pr-comment.js"
 import { getGitHubIDToken, resolveOIDCAudience } from "./oidc.js"
 import { isCommentPermissionError } from "./pr-comment-error.js"
 import { parseSystemdTimespanSeconds } from "./systemd-timespan.js"
+import { classifyProfileContent } from "./post-profile-state.js"
+import { classifyAgentStop, formatAgentStopDetail } from "./post-signal.js"
+import { resolveJobStatusFromGitHub } from "./github-job-status.js"
+import { resolveStopTimeoutFromSettings, resolveStopTimeoutFromUnit } from "./post-stop-timeout.js"
 
 /** @typedef {import("./profile-comment.js").NormalizedProfile} NormalizedProfile */
 /** @typedef {import("./profile-comment.js").RenderOptions} RenderOptions */
+/** @typedef {import("./post-profile-state.js").LoadedProfile} LoadedProfile */
+/** @typedef {import("./post-profile-state.js").ProfileResult} ProfileResult */
+/** @typedef {import("./post-profile-state.js").RootFileStat} RootFileStat */
+/** @typedef {import("./post-signal.js").JibrilUnitState} JibrilUnitState */
+/** @typedef {import("./post-signal.js").AgentStopEvidence} AgentStopEvidence */
+/** @typedef {import("./github-job-status.js").JobStatusResolution} JobStatusResolution */
+/** @typedef {import("./control-plane/types.js").AgentStoppedRequest} AgentStoppedRequest */
+/** @typedef {import("./control-plane/types.js").AgentStoppedJibrilFields} AgentStoppedJibrilFields */
 
 /**
- * @typedef {{ normalized: NormalizedProfile, raw: unknown }} LoadedProfile
+ * Everything the post step observed about how the sensor stopped, from which
+ * the control-plane signal is derived.
+ * @typedef {object} AgentStopObservations
+ * @property {string} agentToken
+ * @property {JibrilUnitState | null} unitStateBeforeStop
+ * @property {JibrilUnitState | null} unitStateAfterStop
+ * @property {"completed" | "timed_out"} stopOutcome
+ * @property {boolean} forceStopped
+ * @property {number} stopTimeoutSeconds
+ * @property {ProfileResult} profileResult
  */
 
 /**
@@ -48,11 +70,11 @@ const DOCS_URL = "https://github.com/garnet-org/action#readme"
 // past it), so the post
 // step waits for the stop to complete — aligned to the unit's own deadline
 // plus a small grace — rather than abandoning a still-deactivating service
-// and losing the profile. The bound stays overridable for consumers that
-// prefer a shorter post step over profile capture on heavy jobs.
+// and losing the profile. The `stop_timeout_seconds` input is the supported
+// knob; this env var stays as an advanced escape hatch and is used verbatim.
 const STOP_TIMEOUT_ENV = "GARNET_POST_STOP_TIMEOUT_SECONDS"
-const FALLBACK_STOP_TIMEOUT_SECONDS = 1800
-const STOP_TIMEOUT_GRACE_SECONDS = 30
+const STOP_TIMEOUT_INPUT = "stop_timeout_seconds"
+
 const PROFILE_WAIT_ENV = "GARNET_POST_PROFILE_WAIT_SECONDS"
 const DEFAULT_PROFILE_WAIT_SECONDS = 60
 const PROFILE_POLL_INTERVAL_MS = 5000
@@ -81,6 +103,13 @@ async function run() {
 
     try {
         const jibrilStarted = core.getState("jibrilStarted") === "true"
+        const agentID = core.getState("agentID")
+        const agentToken = core.getState("agentToken")
+        const jsonProfilerFile = firstNonEmptyString(core.getState("jsonProfilerFile"), getDefaultJsonProfileFile())
+
+        if (agentToken !== "") {
+            core.setSecret(agentToken)
+        }
 
         // Remove secrets from disk (best-effort). Important for self-hosted runners.
         await exec.exec("sudo", ["rm", "-f", "/etc/default/jibril"], {
@@ -92,29 +121,36 @@ async function run() {
             return
         }
 
-        const jsonProfilerFile = firstNonEmptyString(core.getState("jsonProfilerFile"), getDefaultJsonProfileFile())
+        // Read before the stop as well: it is the only way to tell a sensor
+        // that had already crashed from one we timed out waiting on.
+        const unitStateBeforeStop = await readJibrilUnitState()
+        logJibrilUnitState("jibril service state before stop", unitStateBeforeStop)
 
         // Stop the Jibril service and wait for the stop to complete so the
         // daemon flushes all pending events and writes the JSON profile. The
         // wait is aligned to the unit's own stop deadline (TimeoutStopSec)
         // plus a grace period, because the profile is written only when the
         // flush completes: abandoning a still-deactivating service loses it.
-        const stopTimeoutSeconds = await resolveStopTimeoutSeconds()
+        const stopTimeoutSeconds = await resolvePostStopTimeoutSeconds()
+        let stopArgs = ["systemctl", "stop", "jibril.service"]
+        if (stopTimeoutSeconds > 0) {
+            stopArgs = ["timeout", `${stopTimeoutSeconds}s`, ...stopArgs]
+            core.info(`stopping jibril service (waiting up to ${stopTimeoutSeconds}s for the event flush to complete)`)
+        } else {
+            core.info("stopping jibril service (flush bound disabled, waiting for the event flush to complete)")
+        }
+
         const stopStart = Date.now()
-        core.info(`stopping jibril service (waiting up to ${stopTimeoutSeconds}s for the event flush to complete)`)
-        const stopExitCode = await exec.exec(
-            "sudo",
-            ["timeout", `${stopTimeoutSeconds}s`, "systemctl", "stop", "jibril.service"],
-            {
-                ignoreReturnCode: true,
-            },
-        )
+        const stopExitCode = await exec.exec("sudo", stopArgs, {
+            ignoreReturnCode: true,
+        })
+        const stopOutcome = stopExitCode === STOP_TIMED_OUT_EXIT_CODE ? "timed_out" : "completed"
         core.info(`jibril service stop finished in ${Math.round((Date.now() - stopStart) / 1000)}s`)
 
         const profileWaitSeconds = parsePositiveInteger(getEnv(PROFILE_WAIT_ENV), DEFAULT_PROFILE_WAIT_SECONDS)
-        if (stopExitCode === STOP_TIMED_OUT_EXIT_CODE) {
+        if (stopOutcome === "timed_out") {
             core.info(
-                `jibril was still flushing its event backlog after ${stopTimeoutSeconds}s (set ${STOP_TIMEOUT_ENV} to change the bound); ` +
+                `jibril was still flushing its event backlog after ${stopTimeoutSeconds}s (set the ${STOP_TIMEOUT_INPUT} input to change the bound); ` +
                     `waiting up to ${profileWaitSeconds}s more for the ${JSON_PROFILE_LABEL} at ${jsonProfilerFile}`,
             )
         }
@@ -130,7 +166,14 @@ async function run() {
             )
         }
 
-        await logJibrilServiceState()
+        let forceStopped = false
+        if (stopOutcome === "timed_out") {
+            await forceStopJibril()
+            forceStopped = true
+        }
+
+        const unitStateAfterStop = await readJibrilUnitState()
+        logJibrilUnitState("jibril service state", unitStateAfterStop)
 
         // Upload jibril logs as artifacts when debug is enabled (only after service stops).
         // Get the debug state from the main.js.
@@ -139,17 +182,32 @@ async function run() {
             await uploadJibrilArtifacts()
         }
 
-        const profile = await readProfile(jsonProfilerFile, debug === "true")
+        const profileResult = await readProfile(jsonProfilerFile, debug === "true")
         const renderOptions = getRenderOptions()
 
+        const profile = profileResult.profile
         if (profile !== null) {
-            const envelopeID = await resolveProfileEnvelopeID()
+            const envelopeID = await resolveProfileEnvelopeID(agentID)
             if (envelopeID !== "") {
                 // The raw on-disk Jibril profile has no control-plane envelope
                 // ID; wrapping it threads the ID into every render so the
                 // exact public profile selector resolves.
                 profile.raw = { id: envelopeID, data: profile.raw }
             }
+        }
+
+        // A run that produced no usable profile leaves the control plane's
+        // pending state unresolved, so the agent reports how it stopped.
+        if (profileResult.state !== "present" && agentToken !== "") {
+            await reportAgentStop({
+                agentToken,
+                unitStateBeforeStop,
+                unitStateAfterStop,
+                stopOutcome,
+                forceStopped,
+                stopTimeoutSeconds,
+                profileResult,
+            })
         }
 
         await appendRuntimeReviewSummary(profile, renderOptions)
@@ -164,35 +222,160 @@ async function run() {
 }
 
 /**
- * Reads and parses the JSON profile produced by Jibril, or null when the
- * profile is missing or unreadable. Returns both the raw parsed JSON (the
- * Step Summary renders the full-detail report from it, v6.1 §8) and the
- * normalized shape used by the PR-comment state machinery.
+ * Reads and parses the JSON profile produced by Jibril, distinguishing a
+ * missing file from an empty or unparsable one so the control plane can be
+ * told which of them happened.
  * @param {string} jsonProfilerFile
  * @param {boolean} debug
- * @returns {Promise<LoadedProfile | null>}
+ * @returns {Promise<ProfileResult>}
  */
 async function readProfile(jsonProfilerFile, debug) {
     try {
-        const jsonProfile = await readOptionalRootFile(jsonProfilerFile)
-        if (jsonProfile === "") {
-            core.info(`${JSON_PROFILE_LABEL} not found: ${jsonProfilerFile}`)
-            return null
-        }
+        const stat = await statRootFile(jsonProfilerFile)
+        const jsonProfile = stat.exists ? await readOptionalRootFile(jsonProfilerFile) : ""
 
-        if (debug) {
+        if (debug && jsonProfile !== "") {
             core.info(`${JSON_PROFILE_LABEL} contents:`)
             core.info(jsonProfile)
         }
 
-        return {
-            normalized: parseProfileJson(jsonProfile),
-            raw: JSON.parse(jsonProfile),
+        const result = classifyProfileContent(stat, jsonProfile)
+        switch (result.state) {
+            case "missing":
+                core.info(`${JSON_PROFILE_LABEL} not found: ${jsonProfilerFile}`)
+                break
+            case "empty":
+                core.info(`${JSON_PROFILE_LABEL} is empty: ${jsonProfilerFile}`)
+                break
+            case "invalid":
+                core.warning(`failed to parse ${JSON_PROFILE_LABEL}: ${result.detail}`)
+                break
         }
+
+        return result
     } catch (error) {
         core.warning(`failed to read ${JSON_PROFILE_LABEL}: ${getErrorMessage(error)}`)
-        return null
+        return {
+            state: "invalid",
+            profile: null,
+            detail: getErrorMessage(error),
+        }
     }
+}
+
+/**
+ * Reports to the control plane that this run's sensor stopped without leaving
+ * a usable Run Profile, authenticated as the agent itself. Best-effort: every
+ * failure is logged and swallowed so the job stays green.
+ * @param {AgentStopObservations} observations
+ * @returns {Promise<void>}
+ */
+async function reportAgentStop(observations) {
+    try {
+        const jobStatus = await resolveJobStatus()
+
+        /** @type {AgentStopEvidence} */
+        const evidence = {
+            jobStatus: jobStatus.status,
+            unitStateBeforeStop: observations.unitStateBeforeStop,
+            unitStateAfterStop: observations.unitStateAfterStop,
+            stopOutcome: observations.stopOutcome,
+            forceStopped: observations.forceStopped,
+            stopTimeoutSeconds: observations.stopTimeoutSeconds,
+            profileState: observations.profileResult.state,
+        }
+
+        // The evidence detail already names the profile state; only a parse
+        // failure carries extra information worth forwarding.
+        let parseDetail = ""
+        if (observations.profileResult.state === "invalid") {
+            parseDetail = observations.profileResult.detail
+        }
+
+        const request = buildAgentStoppedRequest(evidence, jobStatus, parseDetail)
+        const client = new ControlPlaneClient({
+            baseURL: resolveControlPlaneBaseURL(),
+            agentToken: observations.agentToken,
+        })
+
+        await client.reportAgentStopped(request)
+        core.info(`control plane: reported agent stop (reason=${request.reason}, profile=${request.profile_state})`)
+    } catch (error) {
+        core.info(`control plane: agent stop report skipped: ${getErrorMessage(error)}`)
+    }
+}
+
+/**
+ * Resolves the job's status from the GitHub API (best-effort). The signal is
+ * only used to classify missing-profile runs more accurately.
+ * @returns {Promise<JobStatusResolution>}
+ */
+async function resolveJobStatus() {
+    return resolveJobStatusFromGitHub({
+        token: firstNonEmptyString(core.getState("githubToken"), getEnv("GITHUB_TOKEN")),
+        repository: getEnv("GITHUB_REPOSITORY"),
+        runID: getEnv("GITHUB_RUN_ID"),
+        runAttempt: getEnv("GITHUB_RUN_ATTEMPT"),
+        runnerName: getEnv("RUNNER_NAME"),
+        jobName: getEnv("GITHUB_JOB"),
+    })
+}
+
+/**
+ * @param {AgentStopEvidence} evidence
+ * @param {JobStatusResolution} jobStatus
+ * @param {string} parseDetail
+ * @returns {AgentStoppedRequest}
+ */
+function buildAgentStoppedRequest(evidence, jobStatus, parseDetail) {
+    /** @type {AgentStoppedJibrilFields} */
+    const jibril = {
+        stop_outcome: evidence.stopOutcome,
+        force_stopped: evidence.forceStopped,
+    }
+
+    const unitState = evidence.unitStateAfterStop
+    if (unitState !== null) {
+        jibril.active_state = unitState.activeState
+        jibril.result = unitState.result
+        jibril.exec_main_status = unitState.execMainStatus
+    }
+
+    /** @type {AgentStoppedRequest} */
+    const request = {
+        reason: classifyAgentStop(evidence),
+        profile_state: evidence.profileState,
+        detail: joinDetails(formatAgentStopDetail(evidence), parseDetail),
+        run_id: getEnv("GITHUB_RUN_ID"),
+        jibril,
+    }
+
+    const runAttempt = getEnv("GITHUB_RUN_ATTEMPT")
+    if (runAttempt !== "") {
+        request.run_attempt = runAttempt
+    }
+
+    const job = getProfileJobName()
+    if (job !== "") {
+        request.job = job
+    }
+
+    // The source is only meaningful alongside a status, and "unknown" is
+    // expressed by omitting both.
+    if (jobStatus.status !== "" && jobStatus.source !== "unknown") {
+        request.job_status = jobStatus.status
+        request.job_status_source = jobStatus.source
+    }
+
+    return request
+}
+
+/**
+ * @param {...string} details
+ * @returns {string}
+ */
+function joinDetails(...details) {
+    return details.filter(detail => detail !== "").join("; ")
 }
 
 /**
@@ -200,15 +383,15 @@ async function readProfile(jsonProfilerFile, debug) {
  * the profiles recorded for the agent created in the main step. Fail-closed:
  * any missing credential, missing agent, ambiguity, or request failure
  * returns "" and the render keeps its existing linkless behavior.
+ * @param {string} agentID
  * @returns {Promise<string>}
  */
-async function resolveProfileEnvelopeID() {
-    const agentID = core.getState("agentID")
+async function resolveProfileEnvelopeID(agentID) {
     if (agentID === "") {
         return ""
     }
 
-    const baseURL = firstNonEmptyString(getEnv("GARNET_API_URL"), core.getInput("api_url"), "https://api.garnet.ai")
+    const baseURL = resolveControlPlaneBaseURL()
     const projectToken = firstNonEmptyString(core.getInput("api_token"), getEnv("GARNET_API_TOKEN"))
     const workflowToken = projectToken === "" ? await resolvePostWorkflowToken(baseURL) : ""
     if (projectToken === "" && workflowToken === "") {
@@ -269,6 +452,13 @@ async function resolvePostWorkflowToken(baseURL) {
         core.info(`post-step OIDC exchange skipped: ${getErrorMessage(error)}`)
         return ""
     }
+}
+
+/**
+ * @returns {string}
+ */
+function resolveControlPlaneBaseURL() {
+    return firstNonEmptyString(getEnv("GARNET_API_URL"), core.getInput("api_url"), "https://api.garnet.ai")
 }
 
 /**
@@ -518,12 +708,10 @@ async function waitForRootFile(filePath, deadlineMs) {
 }
 
 /**
- * Logs the jibril unit state so runs with a missing or partial profile
- * carry enough context to diagnose (still deactivating, killed on the
- * stop timeout, or exited cleanly).
- * @returns {Promise<void>}
+ * Reads the jibril unit state for diagnostics and stop-reason classification.
+ * @returns {Promise<JibrilUnitState | null>}
  */
-async function logJibrilServiceState() {
+async function readJibrilUnitState() {
     try {
         const result = await exec.getExecOutput(
             "sudo",
@@ -533,29 +721,71 @@ async function logJibrilServiceState() {
                 ignoreReturnCode: true,
             },
         )
-        const state = result.stdout.trim().split("\n").join(", ")
-        if (state !== "") {
-            core.info(`jibril service state: ${state}`)
+        if (result.exitCode !== 0) {
+            return null
+        }
+
+        const properties = parseSystemctlProperties(result.stdout)
+        return {
+            activeState: properties.get("ActiveState") ?? "",
+            result: properties.get("Result") ?? "",
+            execMainStatus: parseExecMainStatus(properties.get("ExecMainStatus")),
         }
     } catch (error) {
         core.info(`could not read jibril service state: ${getErrorMessage(error)}`)
+        return null
     }
 }
 
 /**
- * Resolves how long the post step waits for `systemctl stop` to complete.
- * An explicit environment override wins; otherwise the unit's own
- * TimeoutStopSec is read live (so the bound tracks the unit instead of a
- * hardcoded copy) plus a grace period, with a fallback when the unit
- * property is unreadable or infinite.
- * @returns {Promise<number>}
+ * @param {string} label
+ * @param {JibrilUnitState | null} state
+ * @returns {void}
  */
-async function resolveStopTimeoutSeconds() {
-    const override = parsePositiveInteger(getEnv(STOP_TIMEOUT_ENV), 0)
-    if (override > 0) {
-        return override
+function logJibrilUnitState(label, state) {
+    if (state === null) {
+        return
     }
 
+    const line = `ActiveState=${state.activeState}, Result=${state.result}, ExecMainStatus=${state.execMainStatus}`
+    core.info(`${label}: ${line}`)
+}
+
+/**
+ * Resolves how long the post step waits for `systemctl stop` to complete.
+ * @returns {Promise<number>}
+ */
+async function resolvePostStopTimeoutSeconds() {
+    const fromSettings = resolveStopTimeoutFromSettings({
+        envOverride: getEnv(STOP_TIMEOUT_ENV),
+        savedState: core.getState("stopTimeoutSeconds"),
+    })
+    if (fromSettings !== null) {
+        return fromSettings
+    }
+
+    // Only runs whose saved state predates `stopTimeoutSeconds` pay for this
+    // extra `systemctl` round-trip.
+    return resolveStopTimeoutFromUnit(await readUnitStopTimeoutSeconds())
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+async function forceStopJibril() {
+    core.warning("force stopping jibril: the shutdown flush did not finish within the configured bound")
+    await exec.exec("sudo", ["systemctl", "kill", "--signal=SIGKILL", "jibril.service"], {
+        ignoreReturnCode: true,
+    })
+    await exec.exec("sudo", ["timeout", "30s", "systemctl", "stop", "jibril.service"], {
+        ignoreReturnCode: true,
+    })
+}
+
+/**
+ * @returns {Promise<number | null>}
+ */
+async function readUnitStopTimeoutSeconds() {
     try {
         const result = await exec.getExecOutput(
             "sudo",
@@ -565,17 +795,15 @@ async function resolveStopTimeoutSeconds() {
                 ignoreReturnCode: true,
             },
         )
-        if (result.exitCode === 0) {
-            const unitSeconds = parseSystemdTimespanSeconds(result.stdout.trim())
-            if (unitSeconds !== null) {
-                return unitSeconds + STOP_TIMEOUT_GRACE_SECONDS
-            }
+        if (result.exitCode !== 0) {
+            return null
         }
+
+        return parseSystemdTimespanSeconds(result.stdout.trim())
     } catch (error) {
         core.info(`could not read jibril unit stop timeout: ${getErrorMessage(error)}`)
+        return null
     }
-
-    return FALLBACK_STOP_TIMEOUT_SECONDS + STOP_TIMEOUT_GRACE_SECONDS
 }
 
 /**
@@ -589,6 +817,23 @@ function parsePositiveInteger(value, def) {
         return parsedValue
     }
     return def
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<RootFileStat>}
+ */
+async function statRootFile(filePath) {
+    const result = await exec.getExecOutput("sudo", ["stat", "-c", "%s", filePath], {
+        silent: true,
+        ignoreReturnCode: true,
+    })
+    if (result.exitCode !== 0) {
+        return { exists: false, size: 0 }
+    }
+
+    const size = Number.parseInt(result.stdout.trim(), 10)
+    return { exists: true, size: Number.isSafeInteger(size) && size > 0 ? size : 0 }
 }
 
 /**
@@ -630,6 +875,35 @@ async function readRootFileContent(filePath) {
     }
 
     return result.stdout.trim()
+}
+
+/**
+ * Parses the `key=value` lines printed by `systemctl show`.
+ * @param {string} output
+ * @returns {Map<string, string>}
+ */
+function parseSystemctlProperties(output) {
+    /** @type {Map<string, string>} */
+    const properties = new Map()
+
+    for (const line of output.split("\n")) {
+        const separatorIndex = line.indexOf("=")
+        if (separatorIndex === -1) {
+            continue
+        }
+        properties.set(line.slice(0, separatorIndex).trim(), line.slice(separatorIndex + 1).trim())
+    }
+
+    return properties
+}
+
+/**
+ * @param {string | undefined} value
+ * @returns {number}
+ */
+function parseExecMainStatus(value) {
+    const parsedValue = Number.parseInt(value ?? "", 10)
+    return Number.isSafeInteger(parsedValue) ? parsedValue : 0
 }
 
 run()

--- a/src/post.js
+++ b/src/post.js
@@ -299,7 +299,7 @@ async function reportAgentStop(observations) {
         })
 
         await client.reportAgentStopped(request)
-        core.info(`control plane: reported agent stop (reason=${request.reason}, profile=${request.profile_state})`)
+        core.info(`control plane: reported agent stop (reason=${request.reason}, profile=${request.profileState})`)
     } catch (error) {
         core.info(`control plane: agent stop report skipped: ${getErrorMessage(error)}`)
     }
@@ -330,29 +330,29 @@ async function resolveJobStatus() {
 function buildAgentStoppedRequest(evidence, jobStatus, parseDetail) {
     /** @type {AgentStoppedJibrilFields} */
     const jibril = {
-        stop_outcome: evidence.stopOutcome,
-        force_stopped: evidence.forceStopped,
+        stopOutcome: evidence.stopOutcome,
+        forceStopped: evidence.forceStopped,
     }
 
     const unitState = evidence.unitStateAfterStop
     if (unitState !== null) {
-        jibril.active_state = unitState.activeState
+        jibril.activeState = unitState.activeState
         jibril.result = unitState.result
-        jibril.exec_main_status = unitState.execMainStatus
+        jibril.execMainStatus = unitState.execMainStatus
     }
 
     /** @type {AgentStoppedRequest} */
     const request = {
         reason: classifyAgentStop(evidence),
-        profile_state: evidence.profileState,
+        profileState: evidence.profileState,
         detail: joinDetails(formatAgentStopDetail(evidence), parseDetail),
-        run_id: getEnv("GITHUB_RUN_ID"),
+        runID: getEnv("GITHUB_RUN_ID"),
         jibril,
     }
 
     const runAttempt = getEnv("GITHUB_RUN_ATTEMPT")
     if (runAttempt !== "") {
-        request.run_attempt = runAttempt
+        request.runAttempt = runAttempt
     }
 
     const job = getProfileJobName()
@@ -362,9 +362,10 @@ function buildAgentStoppedRequest(evidence, jobStatus, parseDetail) {
 
     // The source is only meaningful alongside a status, and "unknown" is
     // expressed by omitting both.
-    if (jobStatus.status !== "" && jobStatus.source !== "unknown") {
-        request.job_status = jobStatus.status
-        request.job_status_source = jobStatus.source
+    const status = toAgentStoppedJobStatus(jobStatus.status)
+    if (status !== "" && jobStatus.source !== "unknown") {
+        request.jobStatus = status
+        request.jobStatusSource = jobStatus.source
     }
 
     return request
@@ -376,6 +377,17 @@ function buildAgentStoppedRequest(evidence, jobStatus, parseDetail) {
  */
 function joinDetails(...details) {
     return details.filter(detail => detail !== "").join("; ")
+}
+
+/**
+ * @param {string} value
+ * @returns {"cancelled" | "failure" | ""}
+ */
+function toAgentStoppedJobStatus(value) {
+    if (value === "cancelled" || value === "failure") {
+        return value
+    }
+    return ""
 }
 
 /**

--- a/test/control-plane-agent-stopped.test.js
+++ b/test/control-plane-agent-stopped.test.js
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict"
+import { createServer } from "node:http"
+import { test } from "node:test"
+import { ControlPlaneClient } from "../src/control-plane/client.js"
+
+/**
+ * @typedef {object} TestServer
+ * @property {string} baseURL
+ * @property {() => Promise<void>} close
+ */
+
+/**
+ * @param {import("node:http").RequestListener} handler
+ * @returns {Promise<TestServer>}
+ */
+async function startServer(handler) {
+    const server = createServer(handler)
+
+    await new Promise((resolve, reject) => {
+        server.once("error", reject)
+        server.listen(0, "127.0.0.1", resolve)
+    })
+
+    const address = server.address()
+    if (address === null || typeof address === "string") {
+        throw new Error("failed to resolve test server address")
+    }
+
+    return {
+        baseURL: `http://127.0.0.1:${address.port}`,
+        close: () => new Promise(resolve => server.close(() => resolve())),
+    }
+}
+
+/**
+ * @param {(req: import("node:http").IncomingMessage, body: string) => void} onRequest
+ * @returns {Promise<TestServer>}
+ */
+function startJsonServer(onRequest) {
+    return startServer((req, res) => {
+        let body = ""
+        req.setEncoding("utf8")
+        req.on("data", chunk => {
+            body += chunk
+        })
+        req.on("end", () => {
+            onRequest(req, body)
+            res.statusCode = 202
+            res.setHeader("content-type", "application/json")
+            res.end("{}")
+        })
+    })
+}
+
+/**
+ * @param {() => void} onRequest
+ * @returns {Promise<TestServer>}
+ */
+function startErrorServer(onRequest) {
+    return startServer((_, res) => {
+        onRequest()
+        res.statusCode = 500
+        res.setHeader("content-type", "application/json")
+        res.end('{"error":"boom"}')
+    })
+}
+
+/**
+ * @typedef {object} CapturedRequest
+ * @property {string} method
+ * @property {string} url
+ * @property {import("node:http").IncomingHttpHeaders} headers
+ * @property {unknown} body
+ */
+
+/**
+ * @returns {import("../src/control-plane/types.js").AgentStoppedRequest}
+ */
+function getReport() {
+    return {
+        reason: "flush_timeout",
+        profile_state: "missing",
+        detail: "stop timed out after 1830s; unit SIGKILLed; profile file missing",
+        run_id: "123456",
+        run_attempt: "1",
+        job: "smoke-c",
+        job_status: "cancelled",
+        job_status_source: "github_api",
+        jibril: {
+            active_state: "failed",
+            result: "signal",
+            exec_main_status: 9,
+            stop_outcome: "timed_out",
+            force_stopped: true,
+        },
+    }
+}
+
+test("reportAgentStopped sends expected payload and uses agent-token auth precedence", async () => {
+    /** @type {CapturedRequest | null} */
+    let captured = null
+
+    const server = await startJsonServer((req, body) => {
+        captured = {
+            method: req.method ?? "",
+            url: req.url ?? "",
+            headers: req.headers,
+            body: JSON.parse(body),
+        }
+    })
+
+    try {
+        const client = new ControlPlaneClient({
+            baseURL: server.baseURL,
+            agentToken: "agent-token-1",
+            workflowToken: "workflow-token-1",
+            projectToken: "project-token-1",
+        })
+
+        await client.reportAgentStopped(getReport())
+
+        assert.ok(captured !== null)
+        assert.equal(captured.method, "POST")
+        assert.equal(captured.url, "/api/v1/agent/stopped")
+        assert.equal(captured.headers["x-agent-token"], "agent-token-1")
+        assert.equal(captured.headers["x-workflow-token"], undefined)
+        assert.equal(captured.headers["x-project-token"], undefined)
+        assert.deepEqual(captured.body, getReport())
+    } finally {
+        await server.close()
+    }
+})
+
+test("reportAgentStopped does not retry on 5xx", async () => {
+    let requestCount = 0
+    const server = await startErrorServer(() => {
+        requestCount += 1
+    })
+
+    try {
+        const client = new ControlPlaneClient({
+            baseURL: server.baseURL,
+            agentToken: "agent-token-1",
+        })
+
+        await assert.rejects(client.reportAgentStopped(getReport()), /HTTP 500/)
+        assert.equal(requestCount, 1)
+    } finally {
+        await server.close()
+    }
+})
+
+test("reportAgentStopped does not retry on network failure", async t => {
+    const originalFetch = globalThis.fetch
+    let fetchCount = 0
+
+    globalThis.fetch = async () => {
+        fetchCount += 1
+        throw new Error("network down")
+    }
+
+    t.after(() => {
+        globalThis.fetch = originalFetch
+    })
+
+    const client = new ControlPlaneClient({
+        baseURL: "http://127.0.0.1:1",
+        agentToken: "agent-token-1",
+    })
+
+    await assert.rejects(client.reportAgentStopped(getReport()), /network error/i)
+    assert.equal(fetchCount, 1)
+})
+
+test("reportAgentStopped schema validation rejects invalid payload", async () => {
+    const client = new ControlPlaneClient({
+        baseURL: "http://127.0.0.1:1",
+        agentToken: "agent-token-1",
+    })
+
+    await assert.rejects(
+        client.reportAgentStopped({
+            reason: "unknown_reason",
+            profile_state: "missing",
+            run_id: "123",
+        }),
+    )
+})

--- a/test/control-plane-agent-stopped.test.js
+++ b/test/control-plane-agent-stopped.test.js
@@ -79,19 +79,19 @@ function startErrorServer(onRequest) {
 function getReport() {
     return {
         reason: "flush_timeout",
-        profile_state: "missing",
+        profileState: "missing",
         detail: "stop timed out after 1830s; unit SIGKILLed; profile file missing",
-        run_id: "123456",
-        run_attempt: "1",
+        runID: "123456",
+        runAttempt: "1",
         job: "smoke-c",
-        job_status: "cancelled",
-        job_status_source: "github_api",
+        jobStatus: "cancelled",
+        jobStatusSource: "github_api",
         jibril: {
-            active_state: "failed",
+            activeState: "failed",
             result: "signal",
-            exec_main_status: 9,
-            stop_outcome: "timed_out",
-            force_stopped: true,
+            execMainStatus: 9,
+            stopOutcome: "timed_out",
+            forceStopped: true,
         },
     }
 }
@@ -181,8 +181,8 @@ test("reportAgentStopped schema validation rejects invalid payload", async () =>
     await assert.rejects(
         client.reportAgentStopped({
             reason: "unknown_reason",
-            profile_state: "missing",
-            run_id: "123",
+            profileState: "missing",
+            runID: "123",
         }),
     )
 })

--- a/test/github-job-status.test.js
+++ b/test/github-job-status.test.js
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { deriveJobStatusFromJobs } from "../src/github-job-status.js"
+
+/** @typedef {import("../src/github-job-status.js").WorkflowRunJob} WorkflowRunJob */
+
+/**
+ * @param {Partial<WorkflowRunJob>=} overrides
+ * @returns {WorkflowRunJob}
+ */
+function createJob(overrides = {}) {
+    return {
+        name: "build",
+        runner_name: "runner-1",
+        status: "in_progress",
+        conclusion: "",
+        steps: [],
+        ...overrides,
+    }
+}
+
+test("deriveJobStatusFromJobs: cancelled conclusion is authoritative", () => {
+    const status = deriveJobStatusFromJobs([createJob({ conclusion: "cancelled" })], {
+        runnerName: "runner-1",
+        jobName: "build",
+    })
+    assert.equal(status, "cancelled")
+})
+
+test("deriveJobStatusFromJobs: step failures are detected", () => {
+    const status = deriveJobStatusFromJobs([createJob({ steps: [{ conclusion: "failure" }] })], {
+        runnerName: "runner-1",
+        jobName: "build",
+    })
+    assert.equal(status, "failure")
+})
+
+test("deriveJobStatusFromJobs: falls back to exact job name when runner match is ambiguous", () => {
+    const status = deriveJobStatusFromJobs(
+        [
+            createJob({ name: "other" }),
+            createJob({ name: "build", conclusion: "cancelled" }),
+        ],
+        {
+            runnerName: "runner-1",
+            jobName: "build",
+        },
+    )
+    assert.equal(status, "cancelled")
+})
+
+test("deriveJobStatusFromJobs: ambiguous or missing matches stay unknown", () => {
+    const ambiguous = deriveJobStatusFromJobs([createJob(), createJob({ name: "build" })], {
+        runnerName: "runner-1",
+        jobName: "build",
+    })
+    assert.equal(ambiguous, "")
+
+    const missing = deriveJobStatusFromJobs([createJob({ runner_name: "runner-2" })], {
+        runnerName: "runner-1",
+        jobName: "build",
+    })
+    assert.equal(missing, "")
+})

--- a/test/post-profile-state.test.js
+++ b/test/post-profile-state.test.js
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import { test } from "node:test"
+import { classifyProfileContent } from "../src/post-profile-state.js"
+
+test("classifyProfileContent: missing file", () => {
+    const result = classifyProfileContent({ exists: false, size: 0 }, "")
+    assert.equal(result.state, "missing")
+    assert.equal(result.profile, null)
+})
+
+test("classifyProfileContent: empty file", () => {
+    const result = classifyProfileContent({ exists: true, size: 10 }, "   \n\t ")
+    assert.equal(result.state, "empty")
+    assert.equal(result.profile, null)
+})
+
+test("classifyProfileContent: invalid profile content", () => {
+    const result = classifyProfileContent({ exists: true, size: 10 }, "{not-json")
+    assert.equal(result.state, "invalid")
+    assert.equal(result.profile, null)
+    assert.notEqual(result.detail, "")
+})
+
+test("classifyProfileContent: present valid profile", async () => {
+    const fixtureURL = new URL("./fixtures/profiles/sample-profile.json", import.meta.url)
+    const content = await readFile(fixtureURL, "utf8")
+    const result = classifyProfileContent({ exists: true, size: content.length }, content)
+
+    assert.equal(result.state, "present")
+    assert.notEqual(result.profile, null)
+    assert.equal(result.detail, "")
+})

--- a/test/post-signal.test.js
+++ b/test/post-signal.test.js
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { classifyAgentStop, formatAgentStopDetail } from "../src/post-signal.js"
+
+/**
+ * @param {Partial<import("../src/post-signal.js").AgentStopEvidence>=} overrides
+ * @returns {import("../src/post-signal.js").AgentStopEvidence}
+ */
+function createEvidence(overrides = {}) {
+    return {
+        jobStatus: "",
+        unitStateBeforeStop: null,
+        unitStateAfterStop: null,
+        stopOutcome: "completed",
+        forceStopped: false,
+        stopTimeoutSeconds: 1830,
+        profileState: "missing",
+        ...overrides,
+    }
+}
+
+test("classifyAgentStop: cancelled status maps to run_cancelled", () => {
+    assert.equal(classifyAgentStop(createEvidence({ jobStatus: "canceled" })), "run_cancelled")
+    assert.equal(classifyAgentStop(createEvidence({ jobStatus: "cancelled" })), "run_cancelled")
+})
+
+test("classifyAgentStop: crashed state wins over flush timeout", () => {
+    const evidence = createEvidence({
+        stopOutcome: "timed_out",
+        unitStateBeforeStop: {
+            activeState: "failed",
+            result: "signal",
+            execMainStatus: 9,
+        },
+    })
+
+    assert.equal(classifyAgentStop(evidence), "crashed")
+})
+
+test("classifyAgentStop: timeout maps to flush_timeout when not crashed", () => {
+    assert.equal(classifyAgentStop(createEvidence({ stopOutcome: "timed_out" })), "flush_timeout")
+})
+
+test("formatAgentStopDetail: timeout + force stop + missing profile", () => {
+    const detail = formatAgentStopDetail(
+        createEvidence({
+            stopOutcome: "timed_out",
+            forceStopped: true,
+            profileState: "missing",
+        }),
+    )
+
+    assert.equal(detail, "stop timed out after 1830s; unit SIGKILLed; profile file missing")
+})

--- a/test/post-stop-timeout.test.js
+++ b/test/post-stop-timeout.test.js
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { resolveStopTimeoutFromSettings, resolveStopTimeoutFromUnit } from "../src/post-stop-timeout.js"
+
+test("settings: env override wins", () => {
+    assert.equal(resolveStopTimeoutFromSettings({ envOverride: "42", savedState: "1800" }), 42)
+})
+
+test("settings: zero or negative disables the timeout", () => {
+    assert.equal(resolveStopTimeoutFromSettings({ envOverride: "0", savedState: "1800" }), 0)
+    assert.equal(resolveStopTimeoutFromSettings({ envOverride: "-1", savedState: "1800" }), 0)
+    assert.equal(resolveStopTimeoutFromSettings({ envOverride: "", savedState: "0" }), 0)
+})
+
+test("settings: saved state gets grace period, invalid values resolve to null", () => {
+    assert.equal(resolveStopTimeoutFromSettings({ envOverride: "", savedState: "1800" }), 1830)
+    assert.equal(resolveStopTimeoutFromSettings({ envOverride: "", savedState: "abc" }), null)
+})
+
+test("unit timeout: readable value gets grace period, unreadable uses default", () => {
+    assert.equal(resolveStopTimeoutFromUnit(600), 630)
+    assert.equal(resolveStopTimeoutFromUnit(null), 1830)
+})

--- a/test/stop-timeout.test.js
+++ b/test/stop-timeout.test.js
@@ -16,10 +16,10 @@ test("positive integer override wins", () => {
 test("non-numeric override falls back to the default", () => {
     assert.equal(resolveStopTimeoutSeconds("ten minutes"), DEFAULT_SECONDS)
     assert.equal(resolveStopTimeoutSeconds("600s"), DEFAULT_SECONDS)
-    assert.equal(resolveStopTimeoutSeconds("-600"), DEFAULT_SECONDS)
     assert.equal(resolveStopTimeoutSeconds("6.5"), DEFAULT_SECONDS)
 })
 
-test("zero override falls back to the default", () => {
-    assert.equal(resolveStopTimeoutSeconds("0"), DEFAULT_SECONDS)
+test("zero or negative override disables the timeout", () => {
+    assert.equal(resolveStopTimeoutSeconds("0"), 0)
+    assert.equal(resolveStopTimeoutSeconds("-600"), 0)
 })


### PR DESCRIPTION
Now we inform control-plane when jibril stops.
There are a few cases, like when jibril crashes, or when `systemd` stops but jibril is still running (flushing large amount of events). Introduced new timeout to kill jibril.
There are also some best-efforts to detect when the workflow run stopped.

All of this is so control-plane can go and update the github comments and not leave pending comments that are never completed.

The new `POST /api/v1/agent/stopped` has not been implemented yet, so this branch should wait until that is implemented at control-plane.